### PR TITLE
geom_alt props

### DIFF
--- a/data/421/182/301/421182301.geojson
+++ b/data/421/182/301/421182301.geojson
@@ -519,6 +519,9 @@
     },
     "wof:country":"LK",
     "wof:created":1459009325,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"38a1f53e5b5ee5a6723aa08b3f7dd53e",
     "wof:hierarchy":[
         {
@@ -530,7 +533,7 @@
         }
     ],
     "wof:id":421182301,
-    "wof:lastmodified":1566595380,
+    "wof:lastmodified":1582345049,
     "wof:name":"Sri Jayewardenepura-Kotte",
     "wof:parent_id":1092059875,
     "wof:placetype":"locality",

--- a/data/421/185/305/421185305.geojson
+++ b/data/421/185/305/421185305.geojson
@@ -262,6 +262,9 @@
     },
     "wof:country":"LK",
     "wof:created":1459009438,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"ae69d78c7cc9b37e3338c25703fddb9a",
     "wof:hierarchy":[
         {
@@ -273,7 +276,7 @@
         }
     ],
     "wof:id":421185305,
-    "wof:lastmodified":1561830631,
+    "wof:lastmodified":1582345049,
     "wof:name":"Matara",
     "wof:parent_id":1092062917,
     "wof:placetype":"locality",

--- a/data/421/191/061/421191061.geojson
+++ b/data/421/191/061/421191061.geojson
@@ -288,6 +288,7 @@
     "qs:woe_id":2189757,
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "quattroshapes_pg"
     ],
     "wd:elevation":8.0,
@@ -312,6 +313,10 @@
     },
     "wof:country":"LK",
     "wof:created":1459009678,
+    "wof:geom_alt":[
+        "naturalearth",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a7d5874b379170f73c7fb4d5763b405b",
     "wof:hierarchy":[
         {
@@ -323,7 +328,7 @@
         }
     ],
     "wof:id":421191061,
-    "wof:lastmodified":1566595375,
+    "wof:lastmodified":1582345049,
     "wof:name":"Trincomalee",
     "wof:parent_id":1092066907,
     "wof:placetype":"locality",

--- a/data/421/201/495/421201495.geojson
+++ b/data/421/201/495/421201495.geojson
@@ -429,6 +429,9 @@
     },
     "wof:country":"LK",
     "wof:created":1459010074,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b1b7f4225bee6df8a7bdbcd6ef3550f2",
     "wof:hierarchy":[
         {
@@ -440,7 +443,7 @@
         }
     ],
     "wof:id":421201495,
-    "wof:lastmodified":1566595377,
+    "wof:lastmodified":1582345049,
     "wof:name":"Colombo",
     "wof:parent_id":1092057419,
     "wof:placetype":"locality",

--- a/data/856/323/13/85632313.geojson
+++ b/data/856/323/13/85632313.geojson
@@ -947,7 +947,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso"
+        "meso",
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
@@ -1001,6 +1002,11 @@
     },
     "wof:country":"LK",
     "wof:country_alpha3":"LKA",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "meso",
+        "naturalearth"
+    ],
     "wof:geomhash":"e60e3bbc6a44feb418ddd75365ffc60a",
     "wof:hierarchy":[
         {
@@ -1017,7 +1023,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594448,
+    "wof:lastmodified":1582345035,
     "wof:name":"Sri Lanka",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/323/13/85632313.geojson
+++ b/data/856/323/13/85632313.geojson
@@ -947,8 +947,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso",
-        "naturalearth"
+        "meso"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
@@ -1023,7 +1022,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1582345035,
+    "wof:lastmodified":1583223872,
     "wof:name":"Sri Lanka",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/737/19/85673719.geojson
+++ b/data/856/737/19/85673719.geojson
@@ -214,6 +214,9 @@
         "wk:page":"Kandy District"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"465656e5047cbc186ceb2ca750105571",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594445,
+    "wof:lastmodified":1582345033,
     "wof:name":"Mahanuvara",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/23/85673723.geojson
+++ b/data/856/737/23/85673723.geojson
@@ -259,6 +259,9 @@
         "wk:page":"Matale District"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bf87cd455448908fd1fc35695b38e344",
     "wof:hierarchy":[
         {
@@ -276,7 +279,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594447,
+    "wof:lastmodified":1582345034,
     "wof:name":"M\u0101tale",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/31/85673731.geojson
+++ b/data/856/737/31/85673731.geojson
@@ -259,6 +259,9 @@
         "wk:page":"Nuwara Eliya District"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"db18a9803a519d13773232d98e7d27ba",
     "wof:hierarchy":[
         {
@@ -276,7 +279,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594445,
+    "wof:lastmodified":1582345033,
     "wof:name":"Nuvara \u0114liya",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/33/85673733.geojson
+++ b/data/856/737/33/85673733.geojson
@@ -259,6 +259,9 @@
         "wd:id":"Q474395"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cf1fa0ff17ae6baab3cb129d4b6f5501",
     "wof:hierarchy":[
         {
@@ -276,7 +279,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594444,
+    "wof:lastmodified":1582345033,
     "wof:name":"Amp\u0101ra",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/37/85673737.geojson
+++ b/data/856/737/37/85673737.geojson
@@ -219,6 +219,9 @@
         "wd:id":"Q810960"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f0c756606ad0aecff509aef24b493479",
     "wof:hierarchy":[
         {
@@ -236,7 +239,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594446,
+    "wof:lastmodified":1582345034,
     "wof:name":"Ma\u1e0dakalapuva",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/43/85673743.geojson
+++ b/data/856/737/43/85673743.geojson
@@ -259,6 +259,9 @@
         "wk:page":"Polonnaruwa District"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c555bc2cfff6e8d002869e906256ce81",
     "wof:hierarchy":[
         {
@@ -276,7 +279,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594445,
+    "wof:lastmodified":1582345033,
     "wof:name":"P\u014f\u1e37\u014fnnaruva",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/47/85673747.geojson
+++ b/data/856/737/47/85673747.geojson
@@ -213,6 +213,9 @@
         "wd:id":"Q1493318"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f2887a33f7828acd7dd2e1f00e041095",
     "wof:hierarchy":[
         {
@@ -230,7 +233,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594447,
+    "wof:lastmodified":1582345034,
     "wof:name":"Triku\u1e47\u0101malaya",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/51/85673751.geojson
+++ b/data/856/737/51/85673751.geojson
@@ -214,6 +214,9 @@
         "wk:page":"Anuradhapura District"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"10f2e272a61c51694693004478d5711b",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594444,
+    "wof:lastmodified":1582345033,
     "wof:name":"Anur\u0101dhapura",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/57/85673757.geojson
+++ b/data/856/737/57/85673757.geojson
@@ -239,6 +239,9 @@
         "wd:id":"Q527980"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e2fc14a4b23e4200650e7aa029c63e01",
     "wof:hierarchy":[
         {
@@ -256,7 +259,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594444,
+    "wof:lastmodified":1582345033,
     "wof:name":"Vavuniy\u0101va",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/61/85673761.geojson
+++ b/data/856/737/61/85673761.geojson
@@ -259,6 +259,9 @@
         "wd:id":"Q178003"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7709352f8b8654379e9aa2b4f77cb33c",
     "wof:hierarchy":[
         {
@@ -276,7 +279,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594443,
+    "wof:lastmodified":1582345033,
     "wof:name":"Mann\u0101rama",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/65/85673765.geojson
+++ b/data/856/737/65/85673765.geojson
@@ -283,6 +283,9 @@
         "wd:id":"Q1587508"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b2adbaa1f11423a5091591e6d99eb4a0",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594446,
+    "wof:lastmodified":1582345033,
     "wof:name":"Mulativ",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/69/85673769.geojson
+++ b/data/856/737/69/85673769.geojson
@@ -213,6 +213,9 @@
         "wd:id":"Q1520182"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"77220a4c56fd6f8ae6cc65e316d0fb22",
     "wof:hierarchy":[
         {
@@ -230,7 +233,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594444,
+    "wof:lastmodified":1582345033,
     "wof:name":"Y\u0101panaya",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/73/85673773.geojson
+++ b/data/856/737/73/85673773.geojson
@@ -259,6 +259,9 @@
         "wd:id":"Q1584007"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3d675775ea442e8adc247cf14817a876",
     "wof:hierarchy":[
         {
@@ -276,7 +279,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594445,
+    "wof:lastmodified":1582345033,
     "wof:name":"Kilin\u014fchchi",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/77/85673777.geojson
+++ b/data/856/737/77/85673777.geojson
@@ -262,6 +262,9 @@
         "wk:page":"Kurunegala District"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"892143ec6429dde0b213d6afbba7518e",
     "wof:hierarchy":[
         {
@@ -279,7 +282,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594446,
+    "wof:lastmodified":1582345034,
     "wof:name":"Kuru\u1e47\u00e6gala",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/79/85673779.geojson
+++ b/data/856/737/79/85673779.geojson
@@ -262,6 +262,9 @@
         "wk:page":"Puttalam District"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"168fa7eb9e926178f54e37a3578860b8",
     "wof:hierarchy":[
         {
@@ -279,7 +282,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594446,
+    "wof:lastmodified":1582345034,
     "wof:name":"Puttalama",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/85/85673785.geojson
+++ b/data/856/737/85/85673785.geojson
@@ -260,6 +260,9 @@
         "wk:page":"Ratnapura District"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8842d65dbe7f9b629bec5a19cfee18f3",
     "wof:hierarchy":[
         {
@@ -277,7 +280,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594447,
+    "wof:lastmodified":1582345034,
     "wof:name":"Ratnapura",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/89/85673789.geojson
+++ b/data/856/737/89/85673789.geojson
@@ -259,6 +259,9 @@
         "wk:page":"Galle District"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"563369d888a12a136809b0f3a4da3846",
     "wof:hierarchy":[
         {
@@ -276,7 +279,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594445,
+    "wof:lastmodified":1582345033,
     "wof:name":"G\u0101lla",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/91/85673791.geojson
+++ b/data/856/737/91/85673791.geojson
@@ -259,6 +259,9 @@
         "wk:page":"Hambantota District"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7e1d8355ccc99732beb394081da50ab1",
     "wof:hierarchy":[
         {
@@ -276,7 +279,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594445,
+    "wof:lastmodified":1582345033,
     "wof:name":"Hambant\u014f\u1e6da",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/95/85673795.geojson
+++ b/data/856/737/95/85673795.geojson
@@ -259,6 +259,9 @@
         "wk:page":"Matara District"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5d439948866d7abed26e4325d8f3743a",
     "wof:hierarchy":[
         {
@@ -276,7 +279,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594443,
+    "wof:lastmodified":1582345033,
     "wof:name":"M\u0101tara",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/738/01/85673801.geojson
+++ b/data/856/738/01/85673801.geojson
@@ -259,6 +259,9 @@
         "wk:page":"Badulla District"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"85c0154a829a7b72ff27f760107b8881",
     "wof:hierarchy":[
         {
@@ -276,7 +279,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594448,
+    "wof:lastmodified":1582345034,
     "wof:name":"Badulla",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/738/03/85673803.geojson
+++ b/data/856/738/03/85673803.geojson
@@ -209,6 +209,9 @@
         "wk:page":"Monaragala District"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c243ff25f545430ef9ed794943408eb6",
     "wof:hierarchy":[
         {
@@ -226,7 +229,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594447,
+    "wof:lastmodified":1582345034,
     "wof:name":"M\u014f\u1e47ar\u0101gala",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/738/07/85673807.geojson
+++ b/data/856/738/07/85673807.geojson
@@ -257,6 +257,9 @@
         "wd:id":"Q1737803"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"56d5290c3123556091a6623a27defa29",
     "wof:hierarchy":[
         {
@@ -274,7 +277,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594448,
+    "wof:lastmodified":1582345034,
     "wof:name":"K\u00e6galla",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/738/11/85673811.geojson
+++ b/data/856/738/11/85673811.geojson
@@ -223,6 +223,9 @@
         "wk:page":"Colombo District"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e1709dcd0955feb635325245cfb73d35",
     "wof:hierarchy":[
         {
@@ -240,7 +243,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594447,
+    "wof:lastmodified":1582345034,
     "wof:name":"K\u014f\u1e37amba",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/738/15/85673815.geojson
+++ b/data/856/738/15/85673815.geojson
@@ -259,6 +259,9 @@
         "wk:page":"Gampaha District"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"866eca3b5de2978983df28f659165ef1",
     "wof:hierarchy":[
         {
@@ -276,7 +279,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594448,
+    "wof:lastmodified":1582345034,
     "wof:name":"Gampaha",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/738/19/85673819.geojson
+++ b/data/856/738/19/85673819.geojson
@@ -258,6 +258,9 @@
         "wk:page":"Kalutara District"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3cbcc8f9bf528c616de1b33ace5528c5",
     "wof:hierarchy":[
         {
@@ -275,7 +278,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1566594448,
+    "wof:lastmodified":1582345034,
     "wof:name":"Ka\u1e37utara",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/857/727/11/85772711.geojson
+++ b/data/857/727/11/85772711.geojson
@@ -72,6 +72,9 @@
         "qs_pg:id":317582
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"481b38a42e05c7cbbb0245a1af2c7bc1",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566594442,
+    "wof:lastmodified":1582345032,
     "wof:name":"Bope",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/727/13/85772713.geojson
+++ b/data/857/727/13/85772713.geojson
@@ -75,6 +75,9 @@
         "qs:id":233047
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"28d6f4a2302e269096672c0f3525d492",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379376,
+    "wof:lastmodified":1582345032,
     "wof:name":"Chiviyateru West",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/727/17/85772717.geojson
+++ b/data/857/727/17/85772717.geojson
@@ -72,6 +72,9 @@
         "qs_pg:id":233050
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c4c6df78706932dfd5615be0fe9fee5a",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566594443,
+    "wof:lastmodified":1582345032,
     "wof:name":"Delkada",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/727/21/85772721.geojson
+++ b/data/857/727/21/85772721.geojson
@@ -86,6 +86,9 @@
         "wk:page":"Fort (Colombo)"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1581811af250a1f708e320dbe1edece3",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566594443,
+    "wof:lastmodified":1582345032,
     "wof:name":"Fort",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/727/25/85772725.geojson
+++ b/data/857/727/25/85772725.geojson
@@ -95,6 +95,9 @@
         "qs_pg:id":1117322
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"38d9448da9431a43424b52022e5f1acc",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566594443,
+    "wof:lastmodified":1582345032,
     "wof:name":"Fort",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/727/31/85772731.geojson
+++ b/data/857/727/31/85772731.geojson
@@ -75,6 +75,9 @@
         "qs:id":1045710
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0e09f729a7f95c9c0417727fd4c60793",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379376,
+    "wof:lastmodified":1582345032,
     "wof:name":"Kaluwella",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/727/35/85772735.geojson
+++ b/data/857/727/35/85772735.geojson
@@ -95,6 +95,9 @@
         "qs_pg:id":1064611
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6074b2fc12a86a3bc3331bb911abeb3a",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566594442,
+    "wof:lastmodified":1582345032,
     "wof:name":"Kapparatota",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/727/37/85772737.geojson
+++ b/data/857/727/37/85772737.geojson
@@ -95,6 +95,9 @@
         "qs_pg:id":1354004
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4c81e64267c73a23c91fca9cc203c6cb",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566594443,
+    "wof:lastmodified":1582345032,
     "wof:name":"Karaiyur",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/727/41/85772741.geojson
+++ b/data/857/727/41/85772741.geojson
@@ -94,6 +94,9 @@
         "qs_pg:id":894796
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4ae459050c3b5ad247442d74b7bbd93d",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566594443,
+    "wof:lastmodified":1582345032,
     "wof:name":"Kohunugamuwa",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/727/51/85772751.geojson
+++ b/data/857/727/51/85772751.geojson
@@ -75,6 +75,9 @@
         "qs:id":1083704
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"21920ed6d48be1a068b84750243e1836",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379376,
+    "wof:lastmodified":1582345032,
     "wof:name":"Kumbalwella",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/727/55/85772755.geojson
+++ b/data/857/727/55/85772755.geojson
@@ -79,6 +79,9 @@
         "qs:id":1354027
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5c0a71d0dc9a14967bf990f381e24dbf",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379376,
+    "wof:lastmodified":1582345032,
     "wof:name":"Kuppiyawatta",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/727/57/85772757.geojson
+++ b/data/857/727/57/85772757.geojson
@@ -72,6 +72,9 @@
         "qs_pg:id":898598
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e6749e2b9f48a0fb4f091c8345e24816",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566594442,
+    "wof:lastmodified":1582345032,
     "wof:name":"Magalla",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/727/61/85772761.geojson
+++ b/data/857/727/61/85772761.geojson
@@ -84,6 +84,9 @@
         "wk:page":"Maradana"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b10aa9ea3a1f8ca640302dbe5b1127f3",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379377,
+    "wof:lastmodified":1582345032,
     "wof:name":"Maradana",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/727/67/85772767.geojson
+++ b/data/857/727/67/85772767.geojson
@@ -84,6 +84,9 @@
         "wk:page":"Mattakkuliya"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cac36ced5a4f87eacf91f4479ce0c280",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566594442,
+    "wof:lastmodified":1582345032,
     "wof:name":"Mattakkuliya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/727/71/85772771.geojson
+++ b/data/857/727/71/85772771.geojson
@@ -77,6 +77,9 @@
         "wk:page":"Modara"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"33f1665abc59b5d0dc569e43ca72aefd",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379376,
+    "wof:lastmodified":1582345032,
     "wof:name":"Mutwal",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/727/75/85772775.geojson
+++ b/data/857/727/75/85772775.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Pettah, Sri Lanka"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"96823ef60645d569db557fa6831a84a1",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379376,
+    "wof:lastmodified":1582345032,
     "wof:name":"Pettah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/727/79/85772779.geojson
+++ b/data/857/727/79/85772779.geojson
@@ -95,6 +95,9 @@
         "qs_pg:id":249057
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e00134dcacfc586183acd056ac871a41",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566594443,
+    "wof:lastmodified":1582345032,
     "wof:name":"Puliyadikuda",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/727/85/85772785.geojson
+++ b/data/857/727/85/85772785.geojson
@@ -84,6 +84,9 @@
         "wk:page":"Slave Island"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8cedfc78e26a3a5a76f691317eeebe8c",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566594443,
+    "wof:lastmodified":1582345032,
     "wof:name":"Slave Island",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/727/89/85772789.geojson
+++ b/data/857/727/89/85772789.geojson
@@ -75,6 +75,9 @@
         "qs:id":1354080
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f217e9f97d859fb2277c4325754b5c27",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379377,
+    "wof:lastmodified":1582345032,
     "wof:name":"Timbirigasyaya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/727/91/85772791.geojson
+++ b/data/857/727/91/85772791.geojson
@@ -95,6 +95,9 @@
         "qs_pg:id":894804
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4e54929c9b602eab5333b9e9ff8554ef",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566594443,
+    "wof:lastmodified":1582345032,
     "wof:name":"Weliweriya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/727/95/85772795.geojson
+++ b/data/857/727/95/85772795.geojson
@@ -89,6 +89,9 @@
         "wd:id":"Q7981177"
     },
     "wof:country":"LK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f01643738ef71301d2dc9d446e8eef6b",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566594442,
+    "wof:lastmodified":1582345032,
     "wof:name":"Wellawatta",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/450/157/890450157.geojson
+++ b/data/890/450/157/890450157.geojson
@@ -200,6 +200,9 @@
     },
     "wof:country":"LK",
     "wof:created":1469052728,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dea638710219dceec5517c9e2bffcf52",
     "wof:hierarchy":[
         {
@@ -210,7 +213,7 @@
         }
     ],
     "wof:id":890450157,
-    "wof:lastmodified":1566595382,
+    "wof:lastmodified":1582345049,
     "wof:name":"Ampara",
     "wof:parent_id":85673733,
     "wof:placetype":"county",

--- a/data/890/455/861/890455861.geojson
+++ b/data/890/455/861/890455861.geojson
@@ -200,6 +200,9 @@
     },
     "wof:country":"LK",
     "wof:created":1469052978,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ab9190f17d0920f4774cb115f39cf4cf",
     "wof:hierarchy":[
         {
@@ -210,7 +213,7 @@
         }
     ],
     "wof:id":890455861,
-    "wof:lastmodified":1566595381,
+    "wof:lastmodified":1582345049,
     "wof:name":"Kegalle",
     "wof:parent_id":85673807,
     "wof:placetype":"county",

--- a/data/890/455/863/890455863.geojson
+++ b/data/890/455/863/890455863.geojson
@@ -152,6 +152,9 @@
     },
     "wof:country":"LK",
     "wof:created":1469052978,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"43f8b01e7ee8a1b0d7a10754f58548c7",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
         }
     ],
     "wof:id":890455863,
-    "wof:lastmodified":1566595381,
+    "wof:lastmodified":1582345049,
     "wof:name":"Jaffna",
     "wof:parent_id":85673769,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.