### PR TITLE
lk concordances, placetype local, and more

### DIFF
--- a/data/109/205/609/1/1092056091.geojson
+++ b/data/109/205/609/1/1092056091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005234,
-    "geom:area_square_m":64202114.455885,
+    "geom:area_square_m":64202175.582557,
     "geom:bbox":"81.769918,7.240902,81.870415,7.307024",
     "geom:latitude":7.273897,
     "geom:longitude":81.821166,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AP.AD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898747,
-    "wof:geomhash":"aa8cb49e4e95ea15c1fe74b2c54bfce0",
+    "wof:geomhash":"e94a518348ecf7b9674f8e1c21c47a61",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092056091,
-    "wof:lastmodified":1627522326,
+    "wof:lastmodified":1695886786,
     "wof:name":"Addalachchenai",
     "wof:parent_id":85673733,
     "wof:placetype":"county",

--- a/data/109/205/612/5/1092056125.geojson
+++ b/data/109/205/612/5/1092056125.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007449,
-    "geom:area_square_m":91516579.876689,
+    "geom:area_square_m":91516567.338832,
     "geom:bbox":"80.116914,6.438093,80.235102,6.580306",
     "geom:latitude":6.515136,
     "geom:longitude":80.174865,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KT.AG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898749,
-    "wof:geomhash":"9a10fde1add6dd5dda55cc6fb4b4c347",
+    "wof:geomhash":"a8668a91f890e36664c9c2c4179c0920",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092056125,
-    "wof:lastmodified":1627522326,
+    "wof:lastmodified":1695886786,
     "wof:name":"Agalawatta",
     "wof:parent_id":85673819,
     "wof:placetype":"county",

--- a/data/109/205/617/1/1092056171.geojson
+++ b/data/109/205/617/1/1092056171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005005,
-    "geom:area_square_m":61392153.049969,
+    "geom:area_square_m":61391934.541524,
     "geom:bbox":"81.707918,7.170389,81.865448,7.25",
     "geom:latitude":7.217239,
     "geom:longitude":81.787192,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AP.AK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898750,
-    "wof:geomhash":"cec9e4acb805a073b3a024d8aebd36ef",
+    "wof:geomhash":"f23271b76d992d0e94740adbe2915c3d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1092056171,
-    "wof:lastmodified":1627522326,
+    "wof:lastmodified":1695886786,
     "wof:name":"Akkaraipattu",
     "wof:parent_id":85673733,
     "wof:placetype":"county",

--- a/data/109/205/621/5/1092056215.geojson
+++ b/data/109/205/621/5/1092056215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005627,
-    "geom:area_square_m":69195848.034561,
+    "geom:area_square_m":69195888.695586,
     "geom:bbox":"80.236531,6.004199,80.354765,6.102954",
     "geom:latitude":6.059189,
     "geom:longitude":80.284208,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GL.AK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898752,
-    "wof:geomhash":"fe529e9fc4e2feed7c631f276c9c6784",
+    "wof:geomhash":"6583a326c93a62cf6aecd66a64c13b92",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092056215,
-    "wof:lastmodified":1627522326,
+    "wof:lastmodified":1695886786,
     "wof:name":"Akmeemana",
     "wof:parent_id":85673789,
     "wof:placetype":"county",

--- a/data/109/205/624/9/1092056249.geojson
+++ b/data/109/205/624/9/1092056249.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002474,
-    "geom:area_square_m":30337620.864622,
+    "geom:area_square_m":30337820.418181,
     "geom:bbox":"80.585984,7.357848,80.660927,7.429074",
     "geom:latitude":7.39046,
     "geom:longitude":80.619491,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KY.AK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898753,
-    "wof:geomhash":"7e7a8e121e0bf3f2b6d86a1d82073a5a",
+    "wof:geomhash":"53fabf551498bb381c0bf6b6760301de",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092056249,
-    "wof:lastmodified":1627522326,
+    "wof:lastmodified":1695886786,
     "wof:name":"Akurana",
     "wof:parent_id":85673719,
     "wof:placetype":"county",

--- a/data/109/205/628/9/1092056289.geojson
+++ b/data/109/205/628/9/1092056289.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012227,
-    "geom:area_square_m":150319187.830955,
+    "geom:area_square_m":150319338.591344,
     "geom:bbox":"80.380374,6.043197,80.497374,6.226004",
     "geom:latitude":6.13652,
     "geom:longitude":80.439239,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MH.AK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898755,
-    "wof:geomhash":"79075982d588d8feaee61c9e40e95f23",
+    "wof:geomhash":"618ddf8084fce8b1868e6210e8a9e568",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092056289,
-    "wof:lastmodified":1627522326,
+    "wof:lastmodified":1695886786,
     "wof:name":"Akuressa",
     "wof:parent_id":85673795,
     "wof:placetype":"county",

--- a/data/109/205/633/5/1092056335.geojson
+++ b/data/109/205/633/5/1092056335.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010819,
-    "geom:area_square_m":132686916.804337,
+    "geom:area_square_m":132686841.64333,
     "geom:bbox":"80.148646,7.256488,80.279943,7.396199",
     "geom:latitude":7.328735,
     "geom:longitude":80.217671,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898756,
-    "wof:geomhash":"6819e47bd748ea2935c8fbc002f93ee8",
+    "wof:geomhash":"95e23256c79f5da36673907c0a2cf743",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092056335,
-    "wof:lastmodified":1627522326,
+    "wof:lastmodified":1695886786,
     "wof:name":"Alawwa",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/205/637/7/1092056377.geojson
+++ b/data/109/205/637/7/1092056377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005931,
-    "geom:area_square_m":72768087.699531,
+    "geom:area_square_m":72768061.76727,
     "geom:bbox":"81.741743,7.128529,81.862915,7.223224",
     "geom:latitude":7.177968,
     "geom:longitude":81.80161,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AP.AL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898758,
-    "wof:geomhash":"d584e56723942202effc42a34b778a13",
+    "wof:geomhash":"7ca4f37c7bb2424ae973311d35323f7a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092056377,
-    "wof:lastmodified":1627522326,
+    "wof:lastmodified":1695886786,
     "wof:name":"Alayadiwembu",
     "wof:parent_id":85673733,
     "wof:placetype":"county",

--- a/data/109/205/640/3/1092056403.geojson
+++ b/data/109/205/640/3/1092056403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039703,
-    "geom:area_square_m":487421418.11589,
+    "geom:area_square_m":487421144.199438,
     "geom:bbox":"80.42967,6.74985,80.774929,7.035525",
     "geom:latitude":6.863733,
     "geom:longitude":80.569759,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.NW.AM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898759,
-    "wof:geomhash":"52bff366c91832eb1af955eeedc1fedf",
+    "wof:geomhash":"f502306fbf62ce0f7ecf774fbd36e6a9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092056403,
-    "wof:lastmodified":1627522326,
+    "wof:lastmodified":1695886786,
     "wof:name":"Ambagamuwa",
     "wof:parent_id":85673731,
     "wof:placetype":"county",

--- a/data/109/205/644/7/1092056447.geojson
+++ b/data/109/205/644/7/1092056447.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003985,
-    "geom:area_square_m":48979391.864124,
+    "geom:area_square_m":48979262.30607,
     "geom:bbox":"80.044218,6.17588,80.145221,6.255959",
     "geom:latitude":6.22335,
     "geom:longitude":80.10263,
@@ -96,9 +96,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GL.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898760,
-    "wof:geomhash":"264071659ef16d079dbdf13af84b4554",
+    "wof:geomhash":"a354f51d92288fd0d8763201c112eeb4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1092056447,
-    "wof:lastmodified":1627522326,
+    "wof:lastmodified":1695886787,
     "wof:name":"Ambalangoda",
     "wof:parent_id":85673789,
     "wof:placetype":"county",

--- a/data/109/205/649/1/1092056491.geojson
+++ b/data/109/205/649/1/1092056491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017682,
-    "geom:area_square_m":217373856.142288,
+    "geom:area_square_m":217373856.142302,
     "geom:bbox":"80.8923607922,6.072083473,81.0348011582,6.2529107797",
     "geom:latitude":6.159831,
     "geom:longitude":80.963523,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"LK.HB.AM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898762,
-    "wof:geomhash":"ba922aa17b2d739c2503c9f511b21681",
+    "wof:geomhash":"a3370ca8d5995927bdf2cd18a6e52eed",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092056491,
-    "wof:lastmodified":1566595275,
+    "wof:lastmodified":1695886707,
     "wof:name":"Ambalantota",
     "wof:parent_id":85673791,
     "wof:placetype":"county",

--- a/data/109/205/652/3/1092056523.geojson
+++ b/data/109/205/652/3/1092056523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00438,
-    "geom:area_square_m":53686874.399587,
+    "geom:area_square_m":53686897.1387,
     "geom:bbox":"80.639676,7.51391,80.714703,7.60249",
     "geom:latitude":7.560148,
     "geom:longitude":80.677356,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MT.AK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898763,
-    "wof:geomhash":"0d3a8b69d183a39bde04691213acb83f",
+    "wof:geomhash":"5a0aa2ad48640f54b8e1cf356aa68b19",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092056523,
-    "wof:lastmodified":1627522327,
+    "wof:lastmodified":1695886787,
     "wof:name":"Ambanganga Korale",
     "wof:parent_id":85673723,
     "wof:placetype":"county",

--- a/data/109/205/656/5/1092056565.geojson
+++ b/data/109/205/656/5/1092056565.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011682,
-    "geom:area_square_m":143078321.749266,
+    "geom:area_square_m":143078328.971719,
     "geom:bbox":"80.158723,7.838913,80.295155,7.978815",
     "geom:latitude":7.907953,
     "geom:longitude":80.223917,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.AM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898765,
-    "wof:geomhash":"a04bf2f57809eb68cea537614743dc2d",
+    "wof:geomhash":"531d67518678b54df733febb8e0e3071",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092056565,
-    "wof:lastmodified":1627522327,
+    "wof:lastmodified":1695886787,
     "wof:name":"Ambanpola",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/205/661/1/1092056611.geojson
+++ b/data/109/205/661/1/1092056611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02102,
-    "geom:area_square_m":257452855.195524,
+    "geom:area_square_m":257452703.782214,
     "geom:bbox":"79.910198,7.778525,80.110456,7.999929",
     "geom:latitude":7.903041,
     "geom:longitude":79.998089,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"LK.PX.AN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898766,
-    "wof:geomhash":"5528d235754f06caab2fa0a0284b4abb",
+    "wof:geomhash":"770e29c3f105ca86a3695005977efd9f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1092056611,
-    "wof:lastmodified":1627522327,
+    "wof:lastmodified":1695886787,
     "wof:name":"Anamaduwa",
     "wof:parent_id":85673779,
     "wof:placetype":"county",

--- a/data/109/205/665/3/1092056653.geojson
+++ b/data/109/205/665/3/1092056653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014146,
-    "geom:area_square_m":173900176.42794,
+    "geom:area_square_m":173900402.441661,
     "geom:bbox":"80.777517,6.118263,80.91935,6.273153",
     "geom:latitude":6.192971,
     "geom:longitude":80.851592,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.HB.AN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898768,
-    "wof:geomhash":"ce1078c67ce370a78995e05317e19595",
+    "wof:geomhash":"d20b105c2a8ed84823015f8f615d1986",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092056653,
-    "wof:lastmodified":1627522327,
+    "wof:lastmodified":1695886787,
     "wof:name":"Angunakolapelessa",
     "wof:parent_id":85673791,
     "wof:placetype":"county",

--- a/data/109/205/669/5/1092056695.geojson
+++ b/data/109/205/669/5/1092056695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013097,
-    "geom:area_square_m":160499150.704015,
+    "geom:area_square_m":160499442.295999,
     "geom:bbox":"79.792358,7.602623,79.912519,7.749938",
     "geom:latitude":7.680754,
     "geom:longitude":79.849421,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.PX.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898769,
-    "wof:geomhash":"67b210969de8dc138b905120bc17aee3",
+    "wof:geomhash":"19f78d5b3a8b0b84a4a16cda53498754",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092056695,
-    "wof:lastmodified":1627522327,
+    "wof:lastmodified":1695886787,
     "wof:name":"Arachchikattuwa",
     "wof:parent_id":85673779,
     "wof:placetype":"county",

--- a/data/109/205/671/7/1092056717.geojson
+++ b/data/109/205/671/7/1092056717.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010268,
-    "geom:area_square_m":125972362.629381,
+    "geom:area_square_m":125972357.580089,
     "geom:bbox":"80.388889,7.086386,80.512606,7.231925",
     "geom:latitude":7.165917,
     "geom:longitude":80.443506,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KE.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898771,
-    "wof:geomhash":"4ecc2fcf62b2a250d2c72b81d1c4a33b",
+    "wof:geomhash":"a953680e821f62692fa03c6c39e571d3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1092056717,
-    "wof:lastmodified":1627522327,
+    "wof:lastmodified":1695886787,
     "wof:name":"Aranayaka",
     "wof:parent_id":85673807,
     "wof:placetype":"county",

--- a/data/109/205/671/9/1092056719.geojson
+++ b/data/109/205/671/9/1092056719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005273,
-    "geom:area_square_m":64828209.80359,
+    "geom:area_square_m":64828147.35847,
     "geom:bbox":"80.477139,6.057542,80.542102,6.18",
     "geom:latitude":6.117103,
     "geom:longitude":80.509498,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MH.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898772,
-    "wof:geomhash":"26bf177e731eb8f9574768f60cceed35",
+    "wof:geomhash":"ccdb16df59b495fd6092ad977bf956b9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092056719,
-    "wof:lastmodified":1627522327,
+    "wof:lastmodified":1695886787,
     "wof:name":"Athuraliya",
     "wof:parent_id":85673795,
     "wof:placetype":"county",

--- a/data/109/205/672/1/1092056721.geojson
+++ b/data/109/205/672/1/1092056721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012743,
-    "geom:area_square_m":156357980.33318,
+    "geom:area_square_m":156358013.711245,
     "geom:bbox":"80.011175,7.057031,80.209734,7.169021",
     "geom:latitude":7.114624,
     "geom:longitude":80.111283,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GQ.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898773,
-    "wof:geomhash":"66b859187d885da43b3a78842dc4b8d0",
+    "wof:geomhash":"8bd0b5295fab26f1feb40324c406069d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092056721,
-    "wof:lastmodified":1627522327,
+    "wof:lastmodified":1695886787,
     "wof:name":"Attanagalla",
     "wof:parent_id":85673815,
     "wof:placetype":"county",

--- a/data/109/205/672/3/1092056723.geojson
+++ b/data/109/205/672/3/1092056723.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01291,
-    "geom:area_square_m":158562274.079131,
+    "geom:area_square_m":158562372.984874,
     "geom:bbox":"80.2019,6.555132,80.385458,6.734003",
     "geom:latitude":6.653507,
     "geom:longitude":80.290437,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.RN.AY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898775,
-    "wof:geomhash":"38362966ae3120fe275549b1da5a0681",
+    "wof:geomhash":"c241c742203ce6dbcfee6e7ebb0ead8d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092056723,
-    "wof:lastmodified":1627522327,
+    "wof:lastmodified":1695886787,
     "wof:name":"Ayagama",
     "wof:parent_id":85673785,
     "wof:placetype":"county",

--- a/data/109/205/676/3/1092056763.geojson
+++ b/data/109/205/676/3/1092056763.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019398,
-    "geom:area_square_m":238136820.213011,
+    "geom:area_square_m":238136842.345482,
     "geom:bbox":"81.114562,6.786939,81.300506,6.96381",
     "geom:latitude":6.870727,
     "geom:longitude":81.217449,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MJ.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898776,
-    "wof:geomhash":"d71f1d9454522c970f369136478cbed0",
+    "wof:geomhash":"e2e65aafeb17f8dcb0309d5797b80393",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092056763,
-    "wof:lastmodified":1627522327,
+    "wof:lastmodified":1695886787,
     "wof:name":"Badalkumbura",
     "wof:parent_id":85673803,
     "wof:placetype":"county",

--- a/data/109/205/680/7/1092056807.geojson
+++ b/data/109/205/680/7/1092056807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009213,
-    "geom:area_square_m":113261745.758615,
+    "geom:area_square_m":113262164.645779,
     "geom:bbox":"80.148013,6.084945,80.304345,6.191203",
     "geom:latitude":6.136669,
     "geom:longitude":80.220526,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GL.BD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898778,
-    "wof:geomhash":"07f672e76e642c16d89b9c1fdc4c41a6",
+    "wof:geomhash":"308b9d68b147eb8a373536b3aa2c9aac",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092056807,
-    "wof:lastmodified":1627522327,
+    "wof:lastmodified":1695886787,
     "wof:name":"Baddegama",
     "wof:parent_id":85673789,
     "wof:placetype":"county",

--- a/data/109/205/684/3/1092056843.geojson
+++ b/data/109/205/684/3/1092056843.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003993,
-    "geom:area_square_m":49002456.24368,
+    "geom:area_square_m":49002430.379348,
     "geom:bbox":"81.044549,6.944778,81.129517,7.017687",
     "geom:latitude":6.98604,
     "geom:longitude":81.090566,
@@ -193,9 +193,10 @@
         "hasc:id":"LK.BD.BD",
         "wd:id":"Q799713"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898779,
-    "wof:geomhash":"9cbf130defde9e34fc44d53d410a5c21",
+    "wof:geomhash":"619cdcdef3549550cbfa48a9298344e2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -205,7 +206,7 @@
         }
     ],
     "wof:id":1092056843,
-    "wof:lastmodified":1690938548,
+    "wof:lastmodified":1695886759,
     "wof:name":"Badulla",
     "wof:parent_id":85673801,
     "wof:placetype":"county",

--- a/data/109/205/688/7/1092056887.geojson
+++ b/data/109/205/688/7/1092056887.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022123,
-    "geom:area_square_m":271724098.216718,
+    "geom:area_square_m":271724111.290069,
     "geom:bbox":"80.595327,6.511741,80.91342,6.727356",
     "geom:latitude":6.628482,
     "geom:longitude":80.767898,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"LK.RN.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898781,
-    "wof:geomhash":"f31998e995ef5bcc581d0f9e8ae9ee98",
+    "wof:geomhash":"d7367c31be357b3c6f59520272e67f18",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1092056887,
-    "wof:lastmodified":1627522327,
+    "wof:lastmodified":1695886787,
     "wof:name":"Balangoda",
     "wof:parent_id":85673785,
     "wof:placetype":"county",

--- a/data/109/205/693/3/1092056933.geojson
+++ b/data/109/205/693/3/1092056933.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00483,
-    "geom:area_square_m":59355888.075308,
+    "geom:area_square_m":59355732.527426,
     "geom:bbox":"80.014666,6.23942,80.080942,6.372096",
     "geom:latitude":6.311961,
     "geom:longitude":80.050434,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GL.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898782,
-    "wof:geomhash":"276c2e7889d184dc4f20bd1acd5518b3",
+    "wof:geomhash":"a446f35b7868399cb2526cd1df5d03de",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092056933,
-    "wof:lastmodified":1627522327,
+    "wof:lastmodified":1695886787,
     "wof:name":"Balapitiya",
     "wof:parent_id":85673789,
     "wof:placetype":"county",

--- a/data/109/205/696/1/1092056961.geojson
+++ b/data/109/205/696/1/1092056961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009,
-    "geom:area_square_m":110318385.443129,
+    "geom:area_square_m":110318257.411191,
     "geom:bbox":"80.172071,7.488105,80.312075,7.598281",
     "geom:latitude":7.548016,
     "geom:longitude":80.252061,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898783,
-    "wof:geomhash":"e984e09e3e55ce6308eef8234ba72594",
+    "wof:geomhash":"b68c25950e3189c1e2393a759bb8caa9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092056961,
-    "wof:lastmodified":1627522327,
+    "wof:lastmodified":1695886787,
     "wof:name":"Bamunakotuwa",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/205/700/9/1092057009.geojson
+++ b/data/109/205/700/9/1092057009.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00463,
-    "geom:area_square_m":56856685.154349,
+    "geom:area_square_m":56856558.683308,
     "geom:bbox":"79.928407,6.683442,80.024264,6.764726",
     "geom:latitude":6.718444,
     "geom:longitude":79.976645,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KT.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898785,
-    "wof:geomhash":"5fef1f9adafa2564a3361f3450373b2d",
+    "wof:geomhash":"239d0f33b13b731b2aa8247542f0d4f6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092057009,
-    "wof:lastmodified":1627522327,
+    "wof:lastmodified":1695886787,
     "wof:name":"Bandaragama",
     "wof:parent_id":85673819,
     "wof:placetype":"county",

--- a/data/109/205/705/9/1092057059.geojson
+++ b/data/109/205/705/9/1092057059.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005813,
-    "geom:area_square_m":71367353.716983,
+    "geom:area_square_m":71367437.332582,
     "geom:bbox":"80.949027,6.788776,81.072728,6.875613",
     "geom:latitude":6.830108,
     "geom:longitude":81.00585,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BD.BN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898786,
-    "wof:geomhash":"73da1d776a8149bebdf5809a04018f08",
+    "wof:geomhash":"f718f5559a7ecf6b4f352709e9c58e7c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092057059,
-    "wof:lastmodified":1627522327,
+    "wof:lastmodified":1695886787,
     "wof:name":"Bandarawela",
     "wof:parent_id":85673801,
     "wof:placetype":"county",

--- a/data/109/205/709/9/1092057099.geojson
+++ b/data/109/205/709/9/1092057099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008251,
-    "geom:area_square_m":101453672.708828,
+    "geom:area_square_m":101453794.202684,
     "geom:bbox":"80.65693,5.99,80.774948,6.116994",
     "geom:latitude":6.051111,
     "geom:longitude":80.720259,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.HB.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898788,
-    "wof:geomhash":"9fdb577af316b5b0492ca19feee3fc2a",
+    "wof:geomhash":"c7e82aedc42ab455d997deedc2131bae",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092057099,
-    "wof:lastmodified":1627522327,
+    "wof:lastmodified":1695886787,
     "wof:name":"Beliatta",
     "wof:parent_id":85673791,
     "wof:placetype":"county",

--- a/data/109/205/713/3/1092057133.geojson
+++ b/data/109/205/713/3/1092057133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006098,
-    "geom:area_square_m":74934560.09603,
+    "geom:area_square_m":74934164.692203,
     "geom:bbox":"79.986252,6.331322,80.137843,6.438573",
     "geom:latitude":6.386431,
     "geom:longitude":80.054016,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GL.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898789,
-    "wof:geomhash":"2c5db5c205de44222a28068d2d21d693",
+    "wof:geomhash":"48e407760c6ef3a92d0a7dfc28fea108",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1092057133,
-    "wof:lastmodified":1627522328,
+    "wof:lastmodified":1695886787,
     "wof:name":"Bentota",
     "wof:parent_id":85673789,
     "wof:placetype":"county",

--- a/data/109/205/715/7/1092057157.geojson
+++ b/data/109/205/715/7/1092057157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006162,
-    "geom:area_square_m":75701714.864426,
+    "geom:area_square_m":75701714.864405,
     "geom:bbox":"79.9663527421,6.42906205643,80.0411024142,6.55592726981",
     "geom:latitude":6.489576,
     "geom:longitude":80.003503,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KT.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898791,
-    "wof:geomhash":"c4432ce44b94625f831020c027dc578a",
+    "wof:geomhash":"2582d1bcaf867daca37f44bd005aa569",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1092057157,
-    "wof:lastmodified":1566595271,
+    "wof:lastmodified":1695886707,
     "wof:name":"Beruwala",
     "wof:parent_id":85673819,
     "wof:placetype":"county",

--- a/data/109/205/715/9/1092057159.geojson
+++ b/data/109/205/715/9/1092057159.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039407,
-    "geom:area_square_m":483448725.681953,
+    "geom:area_square_m":483448387.384218,
     "geom:bbox":"81.120239,7.083481,81.446362,7.339649",
     "geom:latitude":7.189442,
     "geom:longitude":81.29658,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MJ.BI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898792,
-    "wof:geomhash":"9859cad259103c5bf3c30ae628a60fac",
+    "wof:geomhash":"d6d50c072318cb989a92dc479828ef9e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092057159,
-    "wof:lastmodified":1627522328,
+    "wof:lastmodified":1695886787,
     "wof:name":"Bibile",
     "wof:parent_id":85673803,
     "wof:placetype":"county",

--- a/data/109/205/716/1/1092057161.geojson
+++ b/data/109/205/716/1/1092057161.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016218,
-    "geom:area_square_m":198774662.234643,
+    "geom:area_square_m":198774608.244345,
     "geom:bbox":"79.899346,7.518038,80.041235,7.697512",
     "geom:latitude":7.606081,
     "geom:longitude":79.968657,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.BI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898794,
-    "wof:geomhash":"960df0435b4d9ed6df96f7d0673668f1",
+    "wof:geomhash":"c5c453b809f563c190f3bea7b3f8683e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092057161,
-    "wof:lastmodified":1627522328,
+    "wof:lastmodified":1695886787,
     "wof:name":"Bingiriya",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/205/716/3/1092057163.geojson
+++ b/data/109/205/716/3/1092057163.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004912,
-    "geom:area_square_m":60293147.994063,
+    "geom:area_square_m":60293105.163822,
     "geom:bbox":"79.925628,6.936769,80.029468,7.004368",
     "geom:latitude":6.968289,
     "geom:longitude":79.976701,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GQ.BI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898795,
-    "wof:geomhash":"a0a1030f24cc2916dfabc42134da9b33",
+    "wof:geomhash":"d832e151c008db46814f41578b2ab7b7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092057163,
-    "wof:lastmodified":1627522328,
+    "wof:lastmodified":1695886787,
     "wof:name":"Biyagama",
     "wof:parent_id":85673815,
     "wof:placetype":"county",

--- a/data/109/205/720/5/1092057205.geojson
+++ b/data/109/205/720/5/1092057205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002355,
-    "geom:area_square_m":28949913.648592,
+    "geom:area_square_m":28950052.57428,
     "geom:bbox":"80.182347,6.057599,80.24891,6.115224",
     "geom:latitude":6.084415,
     "geom:longitude":80.216144,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GL.BP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898796,
-    "wof:geomhash":"8d96de6e4988da7273dfa8bc6fb90b28",
+    "wof:geomhash":"2264218333b6b127fc71845996a4821f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092057205,
-    "wof:lastmodified":1627522328,
+    "wof:lastmodified":1695886787,
     "wof:name":"Bope-Poddala",
     "wof:parent_id":85673789,
     "wof:placetype":"county",

--- a/data/109/205/724/9/1092057249.geojson
+++ b/data/109/205/724/9/1092057249.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010597,
-    "geom:area_square_m":130024542.577747,
+    "geom:area_square_m":130024841.765141,
     "geom:bbox":"80.280886,7.04178,80.467443,7.168401",
     "geom:latitude":7.096879,
     "geom:longitude":80.358416,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KE.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898798,
-    "wof:geomhash":"9b1aafba197c74a4c142e88a37593d02",
+    "wof:geomhash":"0d35800d34729d45089f10eec10f8061",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092057249,
-    "wof:lastmodified":1627522328,
+    "wof:lastmodified":1695886787,
     "wof:name":"Bulathkohupitiya",
     "wof:parent_id":85673807,
     "wof:placetype":"county",

--- a/data/109/205/728/7/1092057287.geojson
+++ b/data/109/205/728/7/1092057287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016986,
-    "geom:area_square_m":208622632.207137,
+    "geom:area_square_m":208622741.408259,
     "geom:bbox":"80.088805,6.567465,80.253351,6.728036",
     "geom:latitude":6.64793,
     "geom:longitude":80.175719,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KT.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898800,
-    "wof:geomhash":"9cdd2a19c07fda6633cee0cf90696f88",
+    "wof:geomhash":"cfd56b0709d2b0ed8107145d766497df",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092057287,
-    "wof:lastmodified":1627522328,
+    "wof:lastmodified":1695886788,
     "wof:name":"Bulathsinhala",
     "wof:parent_id":85673819,
     "wof:placetype":"county",

--- a/data/109/205/732/9/1092057329.geojson
+++ b/data/109/205/732/9/1092057329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060345,
-    "geom:area_square_m":741145176.557281,
+    "geom:area_square_m":741145169.039191,
     "geom:bbox":"81.142014,6.460978,81.487719,6.811109",
     "geom:latitude":6.655503,
     "geom:longitude":81.294792,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MJ.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898801,
-    "wof:geomhash":"b4a85bac22145c1cfa52fa8304fb5409",
+    "wof:geomhash":"6898fd523726765474e8a4a26f35115f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092057329,
-    "wof:lastmodified":1627522328,
+    "wof:lastmodified":1695886788,
     "wof:name":"Buttala",
     "wof:parent_id":85673803,
     "wof:placetype":"county",

--- a/data/109/205/737/3/1092057373.geojson
+++ b/data/109/205/737/3/1092057373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007602,
-    "geom:area_square_m":93179319.354869,
+    "geom:area_square_m":93179197.716795,
     "geom:bbox":"79.787193,7.514047,79.908301,7.631357",
     "geom:latitude":7.579015,
     "geom:longitude":79.838935,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"LK.PX.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898803,
-    "wof:geomhash":"da6b2f61c69f2cde5fda9c98265fb256",
+    "wof:geomhash":"67d3b77a206cc75c4aee4bd02c0017fb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1092057373,
-    "wof:lastmodified":1627522328,
+    "wof:lastmodified":1695886788,
     "wof:name":"Chilaw",
     "wof:parent_id":85673779,
     "wof:placetype":"county",

--- a/data/109/205/741/9/1092057419.geojson
+++ b/data/109/205/741/9/1092057419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001563,
-    "geom:area_square_m":19186616.469263,
+    "geom:area_square_m":19186616.469244,
     "geom:bbox":"79.840385,6.914368,79.884613,6.983537",
     "geom:latitude":6.943659,
     "geom:longitude":79.863469,
@@ -163,12 +163,13 @@
         "hasc:id":"LK.CO.CO",
         "wd:id":"Q606287"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         421201495
     ],
     "wof:country":"LK",
     "wof:created":1473898804,
-    "wof:geomhash":"94eebcf59172a034e80d83c484b7e245",
+    "wof:geomhash":"705d64891b6f19140bee5119957a874d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -178,7 +179,7 @@
         }
     ],
     "wof:id":1092057419,
-    "wof:lastmodified":1690938548,
+    "wof:lastmodified":1695886403,
     "wof:name":"Colombo",
     "wof:parent_id":85673811,
     "wof:placetype":"county",

--- a/data/109/205/745/9/1092057459.geojson
+++ b/data/109/205/745/9/1092057459.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037685,
-    "geom:area_square_m":462363627.027683,
+    "geom:area_square_m":462363627.027733,
     "geom:bbox":"81.4989769382,6.98488625016,81.7510415145,7.27848256131",
     "geom:latitude":7.140576,
     "geom:longitude":81.627209,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AP.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898806,
-    "wof:geomhash":"9bf9f692b1bc467af242729a267d6c88",
+    "wof:geomhash":"06fb84af4b7f630c945b3ca03c480024",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092057459,
-    "wof:lastmodified":1566595280,
+    "wof:lastmodified":1695886707,
     "wof:name":"Damana",
     "wof:parent_id":85673733,
     "wof:placetype":"county",

--- a/data/109/205/750/3/1092057503.geojson
+++ b/data/109/205/750/3/1092057503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037531,
-    "geom:area_square_m":459695367.311932,
+    "geom:area_square_m":459695367.312018,
     "geom:bbox":"80.6072621001,7.73585699514,80.8478918169,8.01159206949",
     "geom:latitude":7.875643,
     "geom:longitude":80.719454,
@@ -132,9 +132,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MT.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898807,
-    "wof:geomhash":"2aa11cc71802e61134d4059b0e2cc1a1",
+    "wof:geomhash":"945745fcb3d52ee6b5302b577bad7e74",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1092057503,
-    "wof:lastmodified":1566595274,
+    "wof:lastmodified":1695886707,
     "wof:name":"Dambulla",
     "wof:parent_id":85673723,
     "wof:placetype":"county",

--- a/data/109/205/753/3/1092057533.geojson
+++ b/data/109/205/753/3/1092057533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006301,
-    "geom:area_square_m":77272875.542253,
+    "geom:area_square_m":77272893.84448,
     "geom:bbox":"79.861829,7.271943,79.948076,7.381772",
     "geom:latitude":7.320758,
     "geom:longitude":79.905557,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.PX.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898809,
-    "wof:geomhash":"076da9652fd299cc43cb52ed33be03ba",
+    "wof:geomhash":"496b8c70d7f3ee68ac3024215ae59438",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092057533,
-    "wof:lastmodified":1627522328,
+    "wof:lastmodified":1695886788,
     "wof:name":"Dankotuwa",
     "wof:parent_id":85673779,
     "wof:placetype":"county",

--- a/data/109/205/757/7/1092057577.geojson
+++ b/data/109/205/757/7/1092057577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032942,
-    "geom:area_square_m":403727162.586864,
+    "geom:area_square_m":403727021.676815,
     "geom:bbox":"80.979898,7.504739,81.215502,7.730413",
     "geom:latitude":7.624308,
     "geom:longitude":81.086572,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AP.DE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898810,
-    "wof:geomhash":"dc0ece14cbb0d4fe8c2c73b1d9b36c7d",
+    "wof:geomhash":"22a298687d99f8670c1174d69813fca5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092057577,
-    "wof:lastmodified":1627522328,
+    "wof:lastmodified":1695886788,
     "wof:name":"Dehiattakandiya",
     "wof:parent_id":85673733,
     "wof:placetype":"county",

--- a/data/109/205/762/1/1092057621.geojson
+++ b/data/109/205/762/1/1092057621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01576,
-    "geom:area_square_m":193449941.448573,
+    "geom:area_square_m":193449534.761509,
     "geom:bbox":"80.207841,6.830333,80.360073,7.041762",
     "geom:latitude":6.939309,
     "geom:longitude":80.281563,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KE.DH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898812,
-    "wof:geomhash":"701faa000a1f0c7961b3e33327990438",
+    "wof:geomhash":"943a17a35f1b2d1f451f1c609dc7e640",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092057621,
-    "wof:lastmodified":1627522328,
+    "wof:lastmodified":1695886788,
     "wof:name":"Dehiovita",
     "wof:parent_id":85673807,
     "wof:placetype":"county",

--- a/data/109/205/765/7/1092057657.geojson
+++ b/data/109/205/765/7/1092057657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000786,
-    "geom:area_square_m":9645310.910619,
+    "geom:area_square_m":9645392.55674,
     "geom:bbox":"79.855932,6.841385,79.89435,6.873813",
     "geom:latitude":6.858159,
     "geom:longitude":79.874554,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.CO.DM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898813,
-    "wof:geomhash":"ec88e0141b25cabc629e05ee5d8fc9ce",
+    "wof:geomhash":"ca49b02762ea7649f32fa92978402dfa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092057657,
-    "wof:lastmodified":1627522328,
+    "wof:lastmodified":1695886788,
     "wof:name":"Dehiwala",
     "wof:parent_id":85673811,
     "wof:placetype":"county",

--- a/data/109/205/769/9/1092057699.geojson
+++ b/data/109/205/769/9/1092057699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004008,
-    "geom:area_square_m":48876226.207785,
+    "geom:area_square_m":48876226.20778,
     "geom:bbox":"79.652030945,9.474555969,79.732887268,9.553777695",
     "geom:latitude":9.511267,
     "geom:longitude":79.691926,
@@ -282,9 +282,10 @@
     "wof:concordances":{
         "hasc:id":"LK.JA.DE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898815,
-    "wof:geomhash":"03a5fa79c55c7425eda15bd54c6bbf73",
+    "wof:geomhash":"7c635f0bcd3f4b594eba1ac0bdf4f0a7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -294,7 +295,7 @@
         }
     ],
     "wof:id":1092057699,
-    "wof:lastmodified":1566595274,
+    "wof:lastmodified":1695886707,
     "wof:name":"Delft",
     "wof:parent_id":85673769,
     "wof:placetype":"county",

--- a/data/109/205/773/7/1092057737.geojson
+++ b/data/109/205/773/7/1092057737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004054,
-    "geom:area_square_m":49729930.278682,
+    "geom:area_square_m":49730195.381771,
     "geom:bbox":"80.642875,7.128181,80.752033,7.224357",
     "geom:latitude":7.182513,
     "geom:longitude":80.700444,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KY.DE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898816,
-    "wof:geomhash":"0fcf06859a08271c859ae7e3827088e1",
+    "wof:geomhash":"48dfbfad6ee399c09fee7acdcfe88ea5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092057737,
-    "wof:lastmodified":1627522328,
+    "wof:lastmodified":1695886788,
     "wof:name":"Delthota",
     "wof:parent_id":85673719,
     "wof:placetype":"county",

--- a/data/109/205/778/5/1092057785.geojson
+++ b/data/109/205/778/5/1092057785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018238,
-    "geom:area_square_m":223883764.668919,
+    "geom:area_square_m":223883827.750829,
     "geom:bbox":"80.310085,6.828223,80.510816,7.001644",
     "geom:latitude":6.906778,
     "geom:longitude":80.402526,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KE.DR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898817,
-    "wof:geomhash":"6ba39266840670d58372e133409383f8",
+    "wof:geomhash":"bded1d589a8cd7c64e2f631dd99a3218",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092057785,
-    "wof:lastmodified":1627522328,
+    "wof:lastmodified":1695886788,
     "wof:name":"Deraniyagala",
     "wof:parent_id":85673807,
     "wof:placetype":"county",

--- a/data/109/205/780/5/1092057805.geojson
+++ b/data/109/205/780/5/1092057805.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003074,
-    "geom:area_square_m":37800615.576979,
+    "geom:area_square_m":37800607.191657,
     "geom:bbox":"80.575228,5.914556,80.650344,6.025859",
     "geom:latitude":5.973465,
     "geom:longitude":80.613268,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MH.DE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898819,
-    "wof:geomhash":"6ab0041db697b1625ff1bf655f164c43",
+    "wof:geomhash":"a6baf146eef50f07ca1943ddd3158f6e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092057805,
-    "wof:lastmodified":1627522329,
+    "wof:lastmodified":1695886788,
     "wof:name":"Devinuwara",
     "wof:parent_id":85673795,
     "wof:placetype":"county",

--- a/data/109/205/784/5/1092057845.geojson
+++ b/data/109/205/784/5/1092057845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004734,
-    "geom:area_square_m":58220534.92168,
+    "geom:area_square_m":58220492.902567,
     "geom:bbox":"80.625207,5.940389,80.725846,6.02812",
     "geom:latitude":5.982428,
     "geom:longitude":80.672807,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MH.DI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898820,
-    "wof:geomhash":"ff77612269db5811d1a8dfe02bcfd441",
+    "wof:geomhash":"86e515993ae498bb1ed8aa4b897b71ba",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092057845,
-    "wof:lastmodified":1627522329,
+    "wof:lastmodified":1695886788,
     "wof:name":"Dickwella",
     "wof:parent_id":85673795,
     "wof:placetype":"county",

--- a/data/109/205/789/1/1092057891.geojson
+++ b/data/109/205/789/1/1092057891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04554,
-    "geom:area_square_m":557920737.749042,
+    "geom:area_square_m":557920793.73851,
     "geom:bbox":"80.980707,7.646209,81.241872,7.944968",
     "geom:latitude":7.788495,
     "geom:longitude":81.124299,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.PR.DI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898822,
-    "wof:geomhash":"d162598f80b6e51d4a614b0f72f15bd5",
+    "wof:geomhash":"5afda9be13de9a0fc597f41db55e3932",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092057891,
-    "wof:lastmodified":1627522329,
+    "wof:lastmodified":1695886788,
     "wof:name":"Dimbulagala",
     "wof:parent_id":85673743,
     "wof:placetype":"county",

--- a/data/109/205/793/1/1092057931.geojson
+++ b/data/109/205/793/1/1092057931.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016701,
-    "geom:area_square_m":204852929.944628,
+    "geom:area_square_m":204853182.241567,
     "geom:bbox":"79.903976,7.193177,80.120206,7.319267",
     "geom:latitude":7.253634,
     "geom:longitude":80.006965,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GQ.DI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898823,
-    "wof:geomhash":"959fca6204b9f424dad61db327df64f3",
+    "wof:geomhash":"c3ec56533cc307d629d96f1552f478f2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092057931,
-    "wof:lastmodified":1627522329,
+    "wof:lastmodified":1695886788,
     "wof:name":"Divulapitiya",
     "wof:parent_id":85673815,
     "wof:placetype":"county",

--- a/data/109/205/797/1/1092057971.geojson
+++ b/data/109/205/797/1/1092057971.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009201,
-    "geom:area_square_m":113019651.298815,
+    "geom:area_square_m":113019642.073936,
     "geom:bbox":"79.981251,6.482387,80.113121,6.632628",
     "geom:latitude":6.570364,
     "geom:longitude":80.046563,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KT.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898825,
-    "wof:geomhash":"75c9fc01a56ab50edbf98d7f3fd7d353",
+    "wof:geomhash":"e0859691da165d01473e6e264550223a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092057971,
-    "wof:lastmodified":1627522329,
+    "wof:lastmodified":1695886788,
     "wof:name":"Dodangoda",
     "wof:parent_id":85673819,
     "wof:placetype":"county",

--- a/data/109/205/801/3/1092058013.geojson
+++ b/data/109/205/801/3/1092058013.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008193,
-    "geom:area_square_m":100517978.845775,
+    "geom:area_square_m":100517880.956757,
     "geom:bbox":"80.578194,7.091148,80.708733,7.241152",
     "geom:latitude":7.164363,
     "geom:longitude":80.647891,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KY.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898826,
-    "wof:geomhash":"834f9ead8a0834b097ed99f73bf1c324",
+    "wof:geomhash":"73aeffa7b9c40da7f4a39b53b7606713",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092058013,
-    "wof:lastmodified":1627522329,
+    "wof:lastmodified":1695886788,
     "wof:name":"Doluwa",
     "wof:parent_id":85673719,
     "wof:placetype":"county",

--- a/data/109/205/805/5/1092058055.geojson
+++ b/data/109/205/805/5/1092058055.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014811,
-    "geom:area_square_m":181777730.792991,
+    "geom:area_square_m":181777767.847267,
     "geom:bbox":"80.013385,6.908089,80.181922,7.071584",
     "geom:latitude":6.990459,
     "geom:longitude":80.098532,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GQ.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898828,
-    "wof:geomhash":"1cc2a19535f8e593f9b5432d06860dc9",
+    "wof:geomhash":"800e822f0588aa7ad9f4072b6156bf9f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092058055,
-    "wof:lastmodified":1627522329,
+    "wof:lastmodified":1695886788,
     "wof:name":"Dompe",
     "wof:parent_id":85673815,
     "wof:placetype":"county",

--- a/data/109/205/808/9/1092058089.geojson
+++ b/data/109/205/808/9/1092058089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011734,
-    "geom:area_square_m":144067807.866964,
+    "geom:area_square_m":144067412.561123,
     "geom:bbox":"80.175589,6.751227,80.290332,6.929675",
     "geom:latitude":6.837374,
     "geom:longitude":80.22742,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.RN.EH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898829,
-    "wof:geomhash":"8b7c82c177afefbab07e4aed2ae7a60c",
+    "wof:geomhash":"db60ca59e289353f8b7a37598402995e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092058089,
-    "wof:lastmodified":1627522329,
+    "wof:lastmodified":1695886788,
     "wof:name":"Eheliyagoda",
     "wof:parent_id":85673785,
     "wof:placetype":"county",

--- a/data/109/205/813/1/1092058131.geojson
+++ b/data/109/205/813/1/1092058131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01404,
-    "geom:area_square_m":171928506.751077,
+    "geom:area_square_m":171928559.141717,
     "geom:bbox":"80.267427,7.881347,80.426562,8.057048",
     "geom:latitude":7.964764,
     "geom:longitude":80.35783,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.EH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898830,
-    "wof:geomhash":"b2b5ee4805412f829d2db0c0e8064472",
+    "wof:geomhash":"f928613e7a49990d74701ae00811e16c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092058131,
-    "wof:lastmodified":1627522329,
+    "wof:lastmodified":1695886788,
     "wof:name":"Ehetuwewa",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/205/817/7/1092058177.geojson
+++ b/data/109/205/817/7/1092058177.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029054,
-    "geom:area_square_m":355929012.721253,
+    "geom:area_square_m":355929030.534747,
     "geom:bbox":"80.760964,7.672287,80.910858,7.977683",
     "geom:latitude":7.808579,
     "geom:longitude":80.841926,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.PR.EL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898832,
-    "wof:geomhash":"1b8b971a4ffface16a9b29a392795ad6",
+    "wof:geomhash":"5c2e5b56ae9cdaececf9b628b6f0e0b2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092058177,
-    "wof:lastmodified":1627522329,
+    "wof:lastmodified":1695886788,
     "wof:name":"Elahera",
     "wof:parent_id":85673743,
     "wof:placetype":"county",

--- a/data/109/205/821/9/1092058219.geojson
+++ b/data/109/205/821/9/1092058219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007222,
-    "geom:area_square_m":88694279.612451,
+    "geom:area_square_m":88694154.522413,
     "geom:bbox":"80.295635,6.597975,80.408611,6.720629",
     "geom:latitude":6.662496,
     "geom:longitude":80.355647,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.RN.EL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898833,
-    "wof:geomhash":"d0955ddfa5cb352a59f92fa6ee10f5d5",
+    "wof:geomhash":"f166191ad49b1900525a9a7a06254451",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092058219,
-    "wof:lastmodified":1627522329,
+    "wof:lastmodified":1695886788,
     "wof:name":"Elapatha",
     "wof:parent_id":85673785,
     "wof:placetype":"county",

--- a/data/109/205/825/9/1092058259.geojson
+++ b/data/109/205/825/9/1092058259.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008914,
-    "geom:area_square_m":109426775.183643,
+    "geom:area_square_m":109426775.183615,
     "geom:bbox":"80.996937271,6.80683172988,81.1362539983,6.91307520269",
     "geom:latitude":6.867323,
     "geom:longitude":81.066871,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BD.EL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898835,
-    "wof:geomhash":"f3a6884b43d4b1170defacb133d2387b",
+    "wof:geomhash":"bf7a53dda224dcd4f851e3728c2bd447",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1092058259,
-    "wof:lastmodified":1566595276,
+    "wof:lastmodified":1695886707,
     "wof:name":"Ella",
     "wof:parent_id":85673801,
     "wof:placetype":"county",

--- a/data/109/205/830/7/1092058307.geojson
+++ b/data/109/205/830/7/1092058307.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0125,
-    "geom:area_square_m":153635088.991197,
+    "geom:area_square_m":153635309.923964,
     "geom:bbox":"80.129292,6.203055,80.249511,6.369623",
     "geom:latitude":6.29071,
     "geom:longitude":80.186203,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GL.EL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898836,
-    "wof:geomhash":"f05d98c66155ce6b392d08d263b33d8d",
+    "wof:geomhash":"9910339250d85a567dd4ad7ec9237010",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092058307,
-    "wof:lastmodified":1627522329,
+    "wof:lastmodified":1695886788,
     "wof:name":"Elpitiya",
     "wof:parent_id":85673789,
     "wof:placetype":"county",

--- a/data/109/205/834/7/1092058347.geojson
+++ b/data/109/205/834/7/1092058347.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030956,
-    "geom:area_square_m":380427993.901306,
+    "geom:area_square_m":380427993.901329,
     "geom:bbox":"80.6951852197,6.22847761497,80.9519123665,6.48763316734",
     "geom:latitude":6.354362,
     "geom:longitude":80.816042,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"LK.RN.EM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898837,
-    "wof:geomhash":"013d26ca09f222d907bcbbc1e6f4a578",
+    "wof:geomhash":"c6af5f755366ae556acf9166bddd6ca2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092058347,
-    "wof:lastmodified":1566595271,
+    "wof:lastmodified":1695886707,
     "wof:name":"Embilipitiya",
     "wof:parent_id":85673785,
     "wof:placetype":"county",

--- a/data/109/205/837/5/1092058375.geojson
+++ b/data/109/205/837/5/1092058375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050501,
-    "geom:area_square_m":618813241.132361,
+    "geom:area_square_m":618812654.468092,
     "geom:bbox":"81.23289,7.507903,81.659591,7.842853",
     "geom:latitude":7.711231,
     "geom:longitude":81.47034,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BC.EP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898839,
-    "wof:geomhash":"09593a71e5a1f9cf3986972552901abe",
+    "wof:geomhash":"8b99d1c9c4acaa225826e5f45a60ab2c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092058375,
-    "wof:lastmodified":1627522329,
+    "wof:lastmodified":1695886788,
     "wof:name":"Eravur Pattu",
     "wof:parent_id":85673737,
     "wof:placetype":"county",

--- a/data/109/205/842/1/1092058421.geojson
+++ b/data/109/205/842/1/1092058421.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000273,
-    "geom:area_square_m":3339464.28119,
+    "geom:area_square_m":3339613.903267,
     "geom:bbox":"81.596455,7.762413,81.613166,7.784783",
     "geom:latitude":7.77398,
     "geom:longitude":81.605278,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BC.ET"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898840,
-    "wof:geomhash":"940b407d61671bc8826a67502578bde3",
+    "wof:geomhash":"31c9f6628cd067cee30099c877df7a28",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092058421,
-    "wof:lastmodified":1627522329,
+    "wof:lastmodified":1695886788,
     "wof:name":"Eravur Town",
     "wof:parent_id":85673737,
     "wof:placetype":"county",

--- a/data/109/205/846/7/1092058467.geojson
+++ b/data/109/205/846/7/1092058467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023547,
-    "geom:area_square_m":288138361.153809,
+    "geom:area_square_m":288138309.265317,
     "geom:bbox":"80.606984,8.163237,80.808429,8.353461",
     "geom:latitude":8.267199,
     "geom:longitude":80.706915,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.GB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898842,
-    "wof:geomhash":"ae74bb0bae7c58f0dac375874555e22a",
+    "wof:geomhash":"fd3a9e64cc8057b1a6313db9d36494fb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092058467,
-    "wof:lastmodified":1627522329,
+    "wof:lastmodified":1695886788,
     "wof:name":"Galenbindunuwewa",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/205/851/3/1092058513.geojson
+++ b/data/109/205/851/3/1092058513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016334,
-    "geom:area_square_m":200114933.671081,
+    "geom:area_square_m":200115093.772383,
     "geom:bbox":"80.496324,7.669837,80.638815,7.870879",
     "geom:latitude":7.778254,
     "geom:longitude":80.570946,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MT.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898843,
-    "wof:geomhash":"ede18d98c0fd89d2bd52b0631af4f7e2",
+    "wof:geomhash":"dd2869ee30e83b9484330ab30ad9ce19",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092058513,
-    "wof:lastmodified":1627522329,
+    "wof:lastmodified":1695886788,
     "wof:name":"Galewela",
     "wof:parent_id":85673723,
     "wof:placetype":"county",

--- a/data/109/205/854/7/1092058547.geojson
+++ b/data/109/205/854/7/1092058547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022554,
-    "geom:area_square_m":276155712.368073,
+    "geom:area_square_m":276155687.749378,
     "geom:bbox":"80.132847,7.937958,80.368081,8.12",
     "geom:latitude":8.017287,
     "geom:longitude":80.258689,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.GG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898845,
-    "wof:geomhash":"abd2838a858d96b7c7c767d574b61e42",
+    "wof:geomhash":"b59e06cd34de08d7565e414e134c0f12",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092058547,
-    "wof:lastmodified":1627522330,
+    "wof:lastmodified":1695886788,
     "wof:name":"Galgamuwa",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/205/859/5/1092058595.geojson
+++ b/data/109/205/859/5/1092058595.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01027,
-    "geom:area_square_m":125979980.39233,
+    "geom:area_square_m":125979511.067852,
     "geom:bbox":"80.26402,7.109641,80.350054,7.32013",
     "geom:latitude":7.214877,
     "geom:longitude":80.304571,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KE.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898846,
-    "wof:geomhash":"af5b805c0ff3f0f32a76acc0b650bf9b",
+    "wof:geomhash":"62bf241b35ea049fb78731fab65798fd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092058595,
-    "wof:lastmodified":1627522330,
+    "wof:lastmodified":1695886788,
     "wof:name":"Galigamuwa",
     "wof:parent_id":85673807,
     "wof:placetype":"county",

--- a/data/109/205/863/3/1092058633.geojson
+++ b/data/109/205/863/3/1092058633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002204,
-    "geom:area_square_m":27102318.785598,
+    "geom:area_square_m":27102175.162142,
     "geom:bbox":"80.170251,6.018722,80.242336,6.088909",
     "geom:latitude":6.050704,
     "geom:longitude":80.207919,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GL.GF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898847,
-    "wof:geomhash":"8d0d9ee653b154ee7f7dcf985adead43",
+    "wof:geomhash":"413524c3a5a2bf4390b8f40770b4f482",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092058633,
-    "wof:lastmodified":1627522330,
+    "wof:lastmodified":1695886788,
     "wof:name":"Galle Four Gravets",
     "wof:parent_id":85673789,
     "wof:placetype":"county",

--- a/data/109/205/863/5/1092058635.geojson
+++ b/data/109/205/863/5/1092058635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011597,
-    "geom:area_square_m":141997844.18462,
+    "geom:area_square_m":141997955.583699,
     "geom:bbox":"80.358296,7.946034,80.519507,8.090183",
     "geom:latitude":8.019717,
     "geom:longitude":80.449604,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.GN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898849,
-    "wof:geomhash":"41f47f9cef08dbaabc788289ef261df7",
+    "wof:geomhash":"f87db3a1005c53cf8b78765097c6f6ca",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092058635,
-    "wof:lastmodified":1627522330,
+    "wof:lastmodified":1695886788,
     "wof:name":"Galnewa",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/205/864/3/1092058643.geojson
+++ b/data/109/205/864/3/1092058643.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007172,
-    "geom:area_square_m":88011524.120395,
+    "geom:area_square_m":88011562.780407,
     "geom:bbox":"79.924,7.011728,80.054216,7.115657",
     "geom:latitude":7.068745,
     "geom:longitude":79.995588,
@@ -196,9 +196,10 @@
         "hasc:id":"LK.GQ.GA",
         "wd:id":"Q206344"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898850,
-    "wof:geomhash":"28b5776fe0102a99f42f4425c4ac29fa",
+    "wof:geomhash":"d1fb0e2ba802779c0bfb88f4e3a01e39",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -208,7 +209,7 @@
         }
     ],
     "wof:id":1092058643,
-    "wof:lastmodified":1690938549,
+    "wof:lastmodified":1695886759,
     "wof:name":"Gampaha",
     "wof:parent_id":85673815,
     "wof:placetype":"county",

--- a/data/109/205/868/9/1092058689.geojson
+++ b/data/109/205/868/9/1092058689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011914,
-    "geom:area_square_m":146004519.458236,
+    "geom:area_square_m":146004475.484987,
     "geom:bbox":"80.283895,7.573012,80.452632,7.745903",
     "geom:latitude":7.655929,
     "geom:longitude":80.370903,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.GN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898852,
-    "wof:geomhash":"3f80f7b4058b973932fb64e2f96babd4",
+    "wof:geomhash":"5455c940f7238bb2d2a48d46f384c13e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092058689,
-    "wof:lastmodified":1627522330,
+    "wof:lastmodified":1695886788,
     "wof:name":"Ganewatta",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/205/873/5/1092058735.geojson
+++ b/data/109/205/873/5/1092058735.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007237,
-    "geom:area_square_m":88799864.215139,
+    "geom:area_square_m":88799780.720398,
     "geom:bbox":"80.446591,7.063391,80.578914,7.156723",
     "geom:latitude":7.110667,
     "geom:longitude":80.515454,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KY.GI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898853,
-    "wof:geomhash":"3654cb7a3321e18ac8f50956765c1b76",
+    "wof:geomhash":"638fe610f7ba44ac9bff77b155fed6ea",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092058735,
-    "wof:lastmodified":1627522330,
+    "wof:lastmodified":1695886788,
     "wof:name":"Ganga Ihala Korale",
     "wof:parent_id":85673719,
     "wof:placetype":"county",

--- a/data/109/205/878/1/1092058781.geojson
+++ b/data/109/205/878/1/1092058781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017076,
-    "geom:area_square_m":209038569.331931,
+    "geom:area_square_m":209038664.172982,
     "geom:bbox":"80.098412,8.023828,80.271598,8.192452",
     "geom:latitude":8.103782,
     "geom:longitude":80.183949,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.GI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898855,
-    "wof:geomhash":"d45b68125cd0f57c0b58e31fad072c14",
+    "wof:geomhash":"c0bc77342b8a9e841c489a35dcf05874",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092058781,
-    "wof:lastmodified":1627522330,
+    "wof:lastmodified":1695886789,
     "wof:name":"Giribawa",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/205/882/5/1092058825.geojson
+++ b/data/109/205/882/5/1092058825.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012945,
-    "geom:area_square_m":159039824.003749,
+    "geom:area_square_m":159039786.615578,
     "geom:bbox":"80.577281,6.435983,80.750888,6.585963",
     "geom:latitude":6.500088,
     "geom:longitude":80.64158,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.RN.GO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898856,
-    "wof:geomhash":"a2b3488ec8c7accfe9b89d764dbfdb33",
+    "wof:geomhash":"35d06c338e7c257d6a062a2224855142",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092058825,
-    "wof:lastmodified":1627522330,
+    "wof:lastmodified":1695886789,
     "wof:name":"Godakawela",
     "wof:parent_id":85673785,
     "wof:placetype":"county",

--- a/data/109/205/886/3/1092058863.geojson
+++ b/data/109/205/886/3/1092058863.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022901,
-    "geom:area_square_m":279877660.291188,
+    "geom:area_square_m":279877819.322234,
     "geom:bbox":"80.878418,8.64312,81.055996,8.865384",
     "geom:latitude":8.745221,
     "geom:longitude":80.959888,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.TC.GO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898858,
-    "wof:geomhash":"981b8a43b33163577729cf13acf7a913",
+    "wof:geomhash":"60fc64396ae785ce94e5050342d585eb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092058863,
-    "wof:lastmodified":1627522330,
+    "wof:lastmodified":1695886789,
     "wof:name":"Gomarankadawala",
     "wof:parent_id":85673747,
     "wof:placetype":"county",

--- a/data/109/205/888/7/1092058887.geojson
+++ b/data/109/205/888/7/1092058887.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00213,
-    "geom:area_square_m":26189896.620028,
+    "geom:area_square_m":26189819.911353,
     "geom:bbox":"80.100296,6.130092,80.15294,6.205452",
     "geom:latitude":6.166136,
     "geom:longitude":80.131453,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GL.GO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898859,
-    "wof:geomhash":"3647d1ce1323c5c81587aec76d695814",
+    "wof:geomhash":"0f906629888a0aa5dd8c29f7f092923a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092058887,
-    "wof:lastmodified":1627522330,
+    "wof:lastmodified":1695886789,
     "wof:name":"Gonapeenuwala",
     "wof:parent_id":85673789,
     "wof:placetype":"county",

--- a/data/109/205/893/5/1092058935.geojson
+++ b/data/109/205/893/5/1092058935.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004522,
-    "geom:area_square_m":55604545.374478,
+    "geom:area_square_m":55604663.854418,
     "geom:bbox":"80.23378,5.957056,80.385532,6.032926",
     "geom:latitude":5.998705,
     "geom:longitude":80.317427,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GL.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898861,
-    "wof:geomhash":"36acd278fb50c31a442a8ae7e044f1c3",
+    "wof:geomhash":"16f00c1b850e06bdd1d18fd7fe80b95f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092058935,
-    "wof:lastmodified":1627522330,
+    "wof:lastmodified":1695886789,
     "wof:name":"Habaraduwa",
     "wof:parent_id":85673789,
     "wof:placetype":"county",

--- a/data/109/205/897/9/1092058979.geojson
+++ b/data/109/205/897/9/1092058979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003724,
-    "geom:area_square_m":45783550.23715,
+    "geom:area_square_m":45783674.021386,
     "geom:bbox":"80.598027,6.065344,80.697626,6.1319",
     "geom:latitude":6.09606,
     "geom:longitude":80.651448,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MH.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898862,
-    "wof:geomhash":"db6ddec5bf5a1362c42e54977f6d6230",
+    "wof:geomhash":"1aa455e658e3147126b97d068b0223c5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092058979,
-    "wof:lastmodified":1627522330,
+    "wof:lastmodified":1695886789,
     "wof:name":"Hakmana",
     "wof:parent_id":85673795,
     "wof:placetype":"county",

--- a/data/109/205/899/7/1092058997.geojson
+++ b/data/109/205/899/7/1092058997.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034062,
-    "geom:area_square_m":418310328.832961,
+    "geom:area_square_m":418310314.402658,
     "geom:bbox":"80.807177,6.547505,81.08388,6.810146",
     "geom:latitude":6.701393,
     "geom:longitude":80.963744,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BD.HI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898864,
-    "wof:geomhash":"e17780bd0c7e8a61e476ee63858851da",
+    "wof:geomhash":"62a8a8e2d05bbe98698358f996d0d701",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092058997,
-    "wof:lastmodified":1627522330,
+    "wof:lastmodified":1695886789,
     "wof:name":"Haldummulla",
     "wof:parent_id":85673801,
     "wof:placetype":"county",

--- a/data/109/205/905/7/1092059057.geojson
+++ b/data/109/205/905/7/1092059057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013814,
-    "geom:area_square_m":169565393.543288,
+    "geom:area_square_m":169564956.976614,
     "geom:bbox":"80.951919,6.866535,81.123116,7.030732",
     "geom:latitude":6.943141,
     "geom:longitude":81.021454,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BD.HE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898866,
-    "wof:geomhash":"61f55d4bf6d1e434a777145d34dfd4ad",
+    "wof:geomhash":"7971cd78f3af7ca48356c52a3222b0b2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092059057,
-    "wof:lastmodified":1627522330,
+    "wof:lastmodified":1695886789,
     "wof:name":"Hali-Ela",
     "wof:parent_id":85673801,
     "wof:placetype":"county",

--- a/data/109/205/910/1/1092059101.geojson
+++ b/data/109/205/910/1/1092059101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028851,
-    "geom:area_square_m":354655946.825498,
+    "geom:area_square_m":354656009.116493,
     "geom:bbox":"81.016345,6.102564,81.298713,6.340844",
     "geom:latitude":6.202897,
     "geom:longitude":81.123146,
@@ -190,9 +190,10 @@
         "hasc:id":"LK.HB.HA",
         "wd:id":"Q723006"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898867,
-    "wof:geomhash":"9ad754be2e9342a075fb24624df97d8f",
+    "wof:geomhash":"d42830b7f6ab1673b6c2f7135bafc7cf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -202,7 +203,7 @@
         }
     ],
     "wof:id":1092059101,
-    "wof:lastmodified":1690938549,
+    "wof:lastmodified":1695886707,
     "wof:name":"Hambantota",
     "wof:parent_id":85673791,
     "wof:placetype":"county",

--- a/data/109/205/913/9/1092059139.geojson
+++ b/data/109/205/913/9/1092059139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019032,
-    "geom:area_square_m":233520200.454159,
+    "geom:area_square_m":233520512.337145,
     "geom:bbox":"80.698501,6.999175,80.845778,7.268516",
     "geom:latitude":7.119567,
     "geom:longitude":80.778075,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.NW.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898868,
-    "wof:geomhash":"36ba5889955a71d9014ab986285597d1",
+    "wof:geomhash":"48fc5c9f2123f49e5d8248de8b460dee",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092059139,
-    "wof:lastmodified":1627522330,
+    "wof:lastmodified":1695886789,
     "wof:name":"Hanguranketha",
     "wof:parent_id":85673731,
     "wof:placetype":"county",

--- a/data/109/205/918/3/1092059183.geojson
+++ b/data/109/205/918/3/1092059183.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005623,
-    "geom:area_square_m":69038855.382224,
+    "geom:area_square_m":69038801.560566,
     "geom:bbox":"80.906037,6.750133,81.034416,6.839361",
     "geom:latitude":6.791422,
     "geom:longitude":80.96269,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BD.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898870,
-    "wof:geomhash":"89b79ada8ac6efb89a5fe8e693cb505a",
+    "wof:geomhash":"f270a2ede5a2e385a94971a26645d769",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1092059183,
-    "wof:lastmodified":1627522330,
+    "wof:lastmodified":1695886789,
     "wof:name":"Haputale",
     "wof:parent_id":85673801,
     "wof:placetype":"county",

--- a/data/109/205/922/9/1092059229.geojson
+++ b/data/109/205/922/9/1092059229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004187,
-    "geom:area_square_m":51355701.354259,
+    "geom:area_square_m":51355710.613651,
     "geom:bbox":"80.540619,7.280391,80.625012,7.374831",
     "geom:latitude":7.328926,
     "geom:longitude":80.587171,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KY.HP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898871,
-    "wof:geomhash":"8d8dac8e56d8f3037a3fbc24c3805aaa",
+    "wof:geomhash":"bf3a55d40b5f889f8501a2e603b95f35",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092059229,
-    "wof:lastmodified":1627522330,
+    "wof:lastmodified":1695886789,
     "wof:name":"Harispattuwa",
     "wof:parent_id":85673719,
     "wof:placetype":"county",

--- a/data/109/205/927/5/1092059275.geojson
+++ b/data/109/205/927/5/1092059275.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005364,
-    "geom:area_square_m":65785244.906081,
+    "geom:area_square_m":65785435.45479,
     "geom:bbox":"80.420983,7.294026,80.550111,7.377938",
     "geom:latitude":7.330847,
     "geom:longitude":80.481818,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KY.HY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898873,
-    "wof:geomhash":"a6c1d26f2be289f9395cd7836dd4636f",
+    "wof:geomhash":"1e82848d090e2905b0d1cf1241ccf626",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092059275,
-    "wof:lastmodified":1627522331,
+    "wof:lastmodified":1695886789,
     "wof:name":"Hatharaliyadda",
     "wof:parent_id":85673719,
     "wof:placetype":"county",

--- a/data/109/205/931/1/1092059311.geojson
+++ b/data/109/205/931/1/1092059311.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006039,
-    "geom:area_square_m":74250908.441745,
+    "geom:area_square_m":74250908.441742,
     "geom:bbox":"80.048721313,6.06038848412,80.183113136,6.22995280102",
     "geom:latitude":6.140121,
     "geom:longitude":80.119898,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GL.HI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898874,
-    "wof:geomhash":"9fa4ae093cc1217026389e48ce72cc72",
+    "wof:geomhash":"4e8a7cc2397d864a0e1bb609e7cb51e2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1092059311,
-    "wof:lastmodified":1566595266,
+    "wof:lastmodified":1695886706,
     "wof:name":"Hikkaduwa",
     "wof:parent_id":85673789,
     "wof:placetype":"county",

--- a/data/109/205/935/5/1092059355.geojson
+++ b/data/109/205/935/5/1092059355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061503,
-    "geom:area_square_m":752898772.979798,
+    "geom:area_square_m":752898568.151012,
     "geom:bbox":"80.749645,7.911623,81.02893,8.348873",
     "geom:latitude":8.105854,
     "geom:longitude":80.872593,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.PR.HI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898876,
-    "wof:geomhash":"e0c3e71a50884bbce212b01ba1859675",
+    "wof:geomhash":"f63d6ef8222ca157fe76cbf381bd8001",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092059355,
-    "wof:lastmodified":1627522331,
+    "wof:lastmodified":1695886789,
     "wof:name":"Hingurakgoda",
     "wof:parent_id":85673743,
     "wof:placetype":"county",

--- a/data/109/205/939/9/1092059399.geojson
+++ b/data/109/205/939/9/1092059399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009704,
-    "geom:area_square_m":119138284.613882,
+    "geom:area_square_m":119138328.423971,
     "geom:bbox":"79.949468,6.758893,80.081115,6.913605",
     "geom:latitude":6.832987,
     "geom:longitude":80.015969,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.CO.HO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898877,
-    "wof:geomhash":"c5a238a48dbbff5b9a07e50c98173e0d",
+    "wof:geomhash":"d48b698f24c928c4a61932446cc14fc3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092059399,
-    "wof:lastmodified":1627522331,
+    "wof:lastmodified":1695886789,
     "wof:name":"Homagama",
     "wof:parent_id":85673811,
     "wof:placetype":"county",

--- a/data/109/205/943/1/1092059431.geojson
+++ b/data/109/205/943/1/1092059431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009209,
-    "geom:area_square_m":113084702.295801,
+    "geom:area_square_m":113084477.544098,
     "geom:bbox":"79.971322,6.691328,80.111728,6.820216",
     "geom:latitude":6.756342,
     "geom:longitude":80.056074,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KT.HO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898878,
-    "wof:geomhash":"9cef927ca650b68ea15dce40ebd8cce2",
+    "wof:geomhash":"91ab85ad672bbcbb726f94e82baa9193",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092059431,
-    "wof:lastmodified":1627522331,
+    "wof:lastmodified":1695886789,
     "wof:name":"Horana",
     "wof:parent_id":85673819,
     "wof:placetype":"county",

--- a/data/109/205/948/1/1092059481.geojson
+++ b/data/109/205/948/1/1092059481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069298,
-    "geom:area_square_m":847437475.573024,
+    "geom:area_square_m":847437280.772055,
     "geom:bbox":"80.705873,8.277939,80.993661,8.759928",
     "geom:latitude":8.513107,
     "geom:longitude":80.850527,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.HO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898880,
-    "wof:geomhash":"2d8cf0949242b67aeff9035b3388039b",
+    "wof:geomhash":"eaf5dfb78fcfda9bc041a25a8de6dfc9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092059481,
-    "wof:lastmodified":1627522331,
+    "wof:lastmodified":1695886789,
     "wof:name":"Horowpothana",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/205/952/5/1092059525.geojson
+++ b/data/109/205/952/5/1092059525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017891,
-    "geom:area_square_m":219266805.470297,
+    "geom:area_square_m":219266983.02845,
     "geom:bbox":"80.392228,7.505011,80.555621,7.717574",
     "geom:latitude":7.618668,
     "geom:longitude":80.471538,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.IB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898881,
-    "wof:geomhash":"9b4f343a044ecf11f2d1d0a9eededc5f",
+    "wof:geomhash":"3603e886273a6d7864653100479b9e7b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092059525,
-    "wof:lastmodified":1627522331,
+    "wof:lastmodified":1695886789,
     "wof:name":"Ibbagamuwa",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/205/957/3/1092059573.geojson
+++ b/data/109/205/957/3/1092059573.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004998,
-    "geom:area_square_m":61455536.274828,
+    "geom:area_square_m":61455538.642436,
     "geom:bbox":"80.299071,5.992727,80.420174,6.071416",
     "geom:latitude":6.032007,
     "geom:longitude":80.358039,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GL.IM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898883,
-    "wof:geomhash":"210d5ca02b79168a0da653d98126150f",
+    "wof:geomhash":"f453407ce677a1a6749fc74efc7ba373",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092059573,
-    "wof:lastmodified":1627522331,
+    "wof:lastmodified":1695886789,
     "wof:name":"Imaduwa",
     "wof:parent_id":85673789,
     "wof:placetype":"county",

--- a/data/109/205/959/7/1092059597.geojson
+++ b/data/109/205/959/7/1092059597.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020961,
-    "geom:area_square_m":257412496.463923,
+    "geom:area_square_m":257412536.596893,
     "geom:bbox":"80.587762,6.632263,80.858944,6.788483",
     "geom:latitude":6.715237,
     "geom:longitude":80.736914,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.RN.IM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898884,
-    "wof:geomhash":"45c7fce273fddd63336db5acca38f7e1",
+    "wof:geomhash":"7de263231b59857177bbe873e45e1b11",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092059597,
-    "wof:lastmodified":1627522331,
+    "wof:lastmodified":1695886789,
     "wof:name":"Imbulpe",
     "wof:parent_id":85673785,
     "wof:placetype":"county",

--- a/data/109/205/964/3/1092059643.geojson
+++ b/data/109/205/964/3/1092059643.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007766,
-    "geom:area_square_m":95355607.371068,
+    "geom:area_square_m":95355603.039801,
     "geom:bbox":"80.107721,6.698067,80.203725,6.826418",
     "geom:latitude":6.762379,
     "geom:longitude":80.151285,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KT.IN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898886,
-    "wof:geomhash":"c7ea4a3f0a08346c33a8781855ccc2aa",
+    "wof:geomhash":"ed0b6be7a3a34d67a4498ad973f45323",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092059643,
-    "wof:lastmodified":1627522331,
+    "wof:lastmodified":1695886789,
     "wof:name":"Ingiriya",
     "wof:parent_id":85673819,
     "wof:placetype":"county",

--- a/data/109/205/969/1/1092059691.geojson
+++ b/data/109/205/969/1/1092059691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011576,
-    "geom:area_square_m":141711479.016487,
+    "geom:area_square_m":141711710.34699,
     "geom:bbox":"80.418077,7.990904,80.580485,8.152407",
     "geom:latitude":8.086756,
     "geom:longitude":80.507035,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.IP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898887,
-    "wof:geomhash":"a54df1e6cd466227cdac6b1b3469d966",
+    "wof:geomhash":"079733856e4a673d3917b248d3365a51",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092059691,
-    "wof:lastmodified":1627522331,
+    "wof:lastmodified":1695886789,
     "wof:name":"Ipalogama",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/205/972/5/1092059725.geojson
+++ b/data/109/205/972/5/1092059725.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005588,
-    "geom:area_square_m":68544215.884482,
+    "geom:area_square_m":68544456.868258,
     "geom:bbox":"81.680843,7.189539,81.773357,7.296455",
     "geom:latitude":7.243151,
     "geom:longitude":81.728979,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AP.ER"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898888,
-    "wof:geomhash":"9712065cfa699949fd0d24afa5f9b385",
+    "wof:geomhash":"54ca85cc7e4b57bd0bc9f41203c49648",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092059725,
-    "wof:lastmodified":1627522331,
+    "wof:lastmodified":1695886789,
     "wof:name":"Irakkamam",
     "wof:parent_id":85673733,
     "wof:placetype":"county",

--- a/data/109/205/976/5/1092059765.geojson
+++ b/data/109/205/976/5/1092059765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002411,
-    "geom:area_square_m":29394041.441757,
+    "geom:area_square_m":29393984.163439,
     "geom:bbox":"79.764557,9.63797,79.901276,9.707366",
     "geom:latitude":9.674473,
     "geom:longitude":79.849911,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.JA.IR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898890,
-    "wof:geomhash":"6fe56da4d11e4cf22d4a5490f64d5126",
+    "wof:geomhash":"196c967b8c11807c4c31d34f72d19a00",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092059765,
-    "wof:lastmodified":1627522331,
+    "wof:lastmodified":1695886789,
     "wof:name":"Island North (Kayts)",
     "wof:parent_id":85673769,
     "wof:placetype":"county",

--- a/data/109/205/980/7/1092059807.geojson
+++ b/data/109/205/980/7/1092059807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00708,
-    "geom:area_square_m":86314991.734404,
+    "geom:area_square_m":86314920.615626,
     "geom:bbox":"79.762886,9.565389,80.011253,9.677083",
     "geom:latitude":9.620134,
     "geom:longitude":79.894552,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.JA.IS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898891,
-    "wof:geomhash":"ef3e7e7814cc4e353e093b0be2549a8e",
+    "wof:geomhash":"5afc590dafcc38bd697f6c3919632714",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092059807,
-    "wof:lastmodified":1627522331,
+    "wof:lastmodified":1695886789,
     "wof:name":"Island South (Velanai)",
     "wof:parent_id":85673769,
     "wof:placetype":"county",

--- a/data/109/205/985/3/1092059853.geojson
+++ b/data/109/205/985/3/1092059853.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005065,
-    "geom:area_square_m":62153709.035073,
+    "geom:area_square_m":62153795.142622,
     "geom:bbox":"79.865695,7.019632,79.952645,7.122265",
     "geom:latitude":7.071461,
     "geom:longitude":79.909754,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GQ.JE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898893,
-    "wof:geomhash":"599ac39f89b574fac31a164065f307fa",
+    "wof:geomhash":"13721b2bd448d364912fb6d1874104af",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1092059853,
-    "wof:lastmodified":1627522331,
+    "wof:lastmodified":1695886789,
     "wof:name":"Ja-Ela",
     "wof:parent_id":85673815,
     "wof:placetype":"county",

--- a/data/109/205/987/5/1092059875.geojson
+++ b/data/109/205/987/5/1092059875.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007204,
-    "geom:area_square_m":88435677.353089,
+    "geom:area_square_m":88435353.3255,
     "geom:bbox":"79.903064,6.856886,80.045668,6.947825",
     "geom:latitude":6.903652,
     "geom:longitude":79.978154,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"LK.CO.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898894,
-    "wof:geomhash":"87d6768a0cacadf298142e0f963c677d",
+    "wof:geomhash":"a67a08156b8615fbcff30ed06856d5a2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092059875,
-    "wof:lastmodified":1627522331,
+    "wof:lastmodified":1695886790,
     "wof:name":"Kaduwela",
     "wof:parent_id":85673811,
     "wof:placetype":"county",

--- a/data/109/206/003/1/1092060031.geojson
+++ b/data/109/206/003/1/1092060031.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029967,
-    "geom:area_square_m":366546408.784399,
+    "geom:area_square_m":366546420.155657,
     "geom:bbox":"80.59773,8.327328,80.823303,8.563125",
     "geom:latitude":8.421798,
     "geom:longitude":80.711545,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898896,
-    "wof:geomhash":"3f60228b41c68bb6d96a980e5132f8af",
+    "wof:geomhash":"9a13fe61e8bef1bc735b4b43caae6a34",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092060031,
-    "wof:lastmodified":1627522331,
+    "wof:lastmodified":1695886790,
     "wof:name":"Kahatagasdigiliya",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/206/006/7/1092060067.geojson
+++ b/data/109/206/006/7/1092060067.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008376,
-    "geom:area_square_m":102904007.155701,
+    "geom:area_square_m":102904109.144586,
     "geom:bbox":"80.484131,6.460437,80.599614,6.583305",
     "geom:latitude":6.528492,
     "geom:longitude":80.545447,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.RN.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898902,
-    "wof:geomhash":"1de665d3e912b06a655fe088fffe42eb",
+    "wof:geomhash":"31c120858118790dee5811c86515d3b3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092060067,
-    "wof:lastmodified":1627522332,
+    "wof:lastmodified":1695886790,
     "wof:name":"Kahawatta",
     "wof:parent_id":85673785,
     "wof:placetype":"county",

--- a/data/109/206/010/5/1092060105.geojson
+++ b/data/109/206/010/5/1092060105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031605,
-    "geom:area_square_m":388312273.44021,
+    "geom:area_square_m":388312224.021832,
     "geom:bbox":"80.295834,6.367738,80.629103,6.580711",
     "geom:latitude":6.465392,
     "geom:longitude":80.451353,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.RN.KL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898903,
-    "wof:geomhash":"d783ce94dc252ede1af5dd73894e9661",
+    "wof:geomhash":"01678abc7bd3b06407688333dd6dcd62",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092060105,
-    "wof:lastmodified":1627522332,
+    "wof:lastmodified":1695886790,
     "wof:name":"Kalawana",
     "wof:parent_id":85673785,
     "wof:placetype":"county",

--- a/data/109/206/013/9/1092060139.geojson
+++ b/data/109/206/013/9/1092060139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000661,
-    "geom:area_square_m":8109461.84676,
+    "geom:area_square_m":8109395.654554,
     "geom:bbox":"81.7925,7.404266,81.826026,7.449964",
     "geom:latitude":7.423924,
     "geom:longitude":81.808636,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AP.KT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898905,
-    "wof:geomhash":"056926b149246e5880f5ccf493ea9998",
+    "wof:geomhash":"d4fccf1075518381ad2a39ce12afe96d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092060139,
-    "wof:lastmodified":1627522332,
+    "wof:lastmodified":1695886790,
     "wof:name":"Kalmunai Tamil Division",
     "wof:parent_id":85673733,
     "wof:placetype":"county",

--- a/data/109/206/017/9/1092060179.geojson
+++ b/data/109/206/017/9/1092060179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000815,
-    "geom:area_square_m":9988657.089824,
+    "geom:area_square_m":9988657.089808,
     "geom:bbox":"81.8085906794,7.3928930737,81.8469966677,7.44262065605",
     "geom:latitude":7.413193,
     "geom:longitude":81.827652,
@@ -126,9 +126,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AP.KL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898906,
-    "wof:geomhash":"4f3b1bfc5eff04755f6c84fb31557a52",
+    "wof:geomhash":"55fd7aa7ea8b5c23ceb4a33dc0f5f5cf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1092060179,
-    "wof:lastmodified":1566595306,
+    "wof:lastmodified":1695886708,
     "wof:name":"Kalmunai",
     "wof:parent_id":85673733,
     "wof:placetype":"county",

--- a/data/109/206/021/9/1092060219.geojson
+++ b/data/109/206/021/9/1092060219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013534,
-    "geom:area_square_m":165663193.5024,
+    "geom:area_square_m":165663473.471726,
     "geom:bbox":"79.695389,7.92993,79.811583,8.527056",
     "geom:latitude":8.127485,
     "geom:longitude":79.740031,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"LK.PX.KP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898908,
-    "wof:geomhash":"b3f5736ec8038eb3c34c3b52adbf702b",
+    "wof:geomhash":"2e8fbf08ce2f0c9c284b1b03fef3c645",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092060219,
-    "wof:lastmodified":1627522332,
+    "wof:lastmodified":1695886790,
     "wof:name":"Kalpitiya",
     "wof:parent_id":85673779,
     "wof:placetype":"county",

--- a/data/109/206/023/9/1092060239.geojson
+++ b/data/109/206/023/9/1092060239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006743,
-    "geom:area_square_m":82817799.678899,
+    "geom:area_square_m":82817830.263178,
     "geom:bbox":"79.926852,6.539034,80.009924,6.690765",
     "geom:latitude":6.618665,
     "geom:longitude":79.970219,
@@ -188,9 +188,10 @@
         "hasc:id":"LK.KT.KA",
         "wd:id":"Q728935"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898909,
-    "wof:geomhash":"12a36bc88712a98806061fc5300124f7",
+    "wof:geomhash":"15f3245e8a7225ec7226884967df7231",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -200,7 +201,7 @@
         }
     ],
     "wof:id":1092060239,
-    "wof:lastmodified":1690938550,
+    "wof:lastmodified":1695886707,
     "wof:name":"Kalutara",
     "wof:parent_id":85673819,
     "wof:placetype":"county",

--- a/data/109/206/028/1/1092060281.geojson
+++ b/data/109/206/028/1/1092060281.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004951,
-    "geom:area_square_m":60875889.922542,
+    "geom:area_square_m":60876061.302938,
     "geom:bbox":"80.508603,6.026858,80.616527,6.103799",
     "geom:latitude":6.066227,
     "geom:longitude":80.562294,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MH.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898911,
-    "wof:geomhash":"811c871d68607555bd10ebfa9ab2cf27",
+    "wof:geomhash":"988d1f81acf6a5e9c6e7f7841bf26d07",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092060281,
-    "wof:lastmodified":1627522332,
+    "wof:lastmodified":1695886790,
     "wof:name":"Kamburupitiya",
     "wof:parent_id":85673795,
     "wof:placetype":"county",

--- a/data/109/206/031/9/1092060319.geojson
+++ b/data/109/206/031/9/1092060319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012566,
-    "geom:area_square_m":154176620.224402,
+    "geom:area_square_m":154176547.327663,
     "geom:bbox":"80.944927,7.018744,81.041548,7.228217",
     "geom:latitude":7.129745,
     "geom:longitude":80.993873,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BD.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898912,
-    "wof:geomhash":"05bcca1b2ffa9b1ec7415184daa732ff",
+    "wof:geomhash":"d2486dfebeda03dbdf21d51a48b769f1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092060319,
-    "wof:lastmodified":1627522332,
+    "wof:lastmodified":1695886790,
     "wof:name":"Kandaketiya",
     "wof:parent_id":85673801,
     "wof:placetype":"county",

--- a/data/109/206/035/5/1092060355.geojson
+++ b/data/109/206/035/5/1092060355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022092,
-    "geom:area_square_m":269467241.692113,
+    "geom:area_square_m":269467391.16616,
     "geom:bbox":"80.348798,9.359225,80.61587,9.523869",
     "geom:latitude":9.44931,
     "geom:longitude":80.486977,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KL.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898913,
-    "wof:geomhash":"13f2e4adaf876c15fba41b7da92df7cd",
+    "wof:geomhash":"f4d3154d3b12fa450fce554bce1de4d0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092060355,
-    "wof:lastmodified":1627522332,
+    "wof:lastmodified":1695886790,
     "wof:name":"Kandavalai",
     "wof:parent_id":85673773,
     "wof:placetype":"county",

--- a/data/109/206/038/3/1092060383.geojson
+++ b/data/109/206/038/3/1092060383.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004294,
-    "geom:area_square_m":52668779.464941,
+    "geom:area_square_m":52669034.770636,
     "geom:bbox":"80.588432,7.218917,80.688491,7.328247",
     "geom:latitude":7.273907,
     "geom:longitude":80.631581,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KY.KG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898915,
-    "wof:geomhash":"85acb7deca99447735ba6e09af6b0593",
+    "wof:geomhash":"8919a4721a442acc3fedb093f6c66576",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092060383,
-    "wof:lastmodified":1627522332,
+    "wof:lastmodified":1695886790,
     "wof:name":"Kandy Four Gravets & Gangawata Korale",
     "wof:parent_id":85673719,
     "wof:placetype":"county",

--- a/data/109/206/042/5/1092060425.geojson
+++ b/data/109/206/042/5/1092060425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033279,
-    "geom:area_square_m":407147998.796783,
+    "geom:area_square_m":407147980.220097,
     "geom:bbox":"80.926047,8.231087,81.204726,8.452083",
     "geom:latitude":8.345989,
     "geom:longitude":81.057152,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.TC.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898917,
-    "wof:geomhash":"5b81179b73227eddbecf1f876cab1149",
+    "wof:geomhash":"ae85bf76bd6d18cf808db5bf986c6671",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092060425,
-    "wof:lastmodified":1627522332,
+    "wof:lastmodified":1695886790,
     "wof:name":"Kanthalai",
     "wof:parent_id":85673747,
     "wof:placetype":"county",

--- a/data/109/206/046/5/1092060465.geojson
+++ b/data/109/206/046/5/1092060465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02561,
-    "geom:area_square_m":312454727.798221,
+    "geom:area_square_m":312454532.198521,
     "geom:bbox":"80.227976,9.297241,80.521382,9.467055",
     "geom:latitude":9.368168,
     "geom:longitude":80.36991,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KL.KR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898918,
-    "wof:geomhash":"aa9eba1e46769a2baaa27c908a28d141",
+    "wof:geomhash":"c831fd9cd78ec1358a3e3c367cc27a01",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092060465,
-    "wof:lastmodified":1627522332,
+    "wof:lastmodified":1695886790,
     "wof:name":"Karachchi",
     "wof:parent_id":85673773,
     "wof:placetype":"county",

--- a/data/109/206/050/7/1092060507.geojson
+++ b/data/109/206/050/7/1092060507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001956,
-    "geom:area_square_m":23839212.588931,
+    "geom:area_square_m":23839212.588903,
     "geom:bbox":"79.852027893,9.702055931,79.900390625,9.764611244",
     "geom:latitude":9.733778,
     "geom:longitude":79.876544,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"LK.JA.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898920,
-    "wof:geomhash":"2c61e69f0b149b5afcd9728d2e04ec70",
+    "wof:geomhash":"5aa1bef369609e9256eabe0fb0af2159",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1092060507,
-    "wof:lastmodified":1566595309,
+    "wof:lastmodified":1695886708,
     "wof:name":"Karainagar",
     "wof:parent_id":85673769,
     "wof:placetype":"county",

--- a/data/109/206/054/5/1092060545.geojson
+++ b/data/109/206/054/5/1092060545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00058,
-    "geom:area_square_m":7117195.809498,
+    "geom:area_square_m":7117114.996488,
     "geom:bbox":"81.821418,7.358873,81.854588,7.395144",
     "geom:latitude":7.372003,
     "geom:longitude":81.839585,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AP.KR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898922,
-    "wof:geomhash":"81ee990278ed8c6b76bd29c3599db12f",
+    "wof:geomhash":"c486abdfbcde43063a19baa62fab9c05",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092060545,
-    "wof:lastmodified":1627522332,
+    "wof:lastmodified":1695886790,
     "wof:name":"Karaitheevu",
     "wof:parent_id":85673733,
     "wof:placetype":"county",

--- a/data/109/206/057/9/1092060579.geojson
+++ b/data/109/206/057/9/1092060579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007094,
-    "geom:area_square_m":87185399.072502,
+    "geom:area_square_m":87185475.538777,
     "geom:bbox":"80.062412,6.245528,80.150136,6.379311",
     "geom:latitude":6.300902,
     "geom:longitude":80.100697,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GL.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898923,
-    "wof:geomhash":"ddac4e294b96956456a8c23605824e0d",
+    "wof:geomhash":"9ddd72f7c6ea4be31280feb0f136a1d9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092060579,
-    "wof:lastmodified":1627522332,
+    "wof:lastmodified":1695886790,
     "wof:name":"Karandeniya",
     "wof:parent_id":85673789,
     "wof:placetype":"county",

--- a/data/109/206/059/5/1092060595.geojson
+++ b/data/109/206/059/5/1092060595.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041191,
-    "geom:area_square_m":504228518.31555,
+    "geom:area_square_m":504228438.097213,
     "geom:bbox":"79.894617,7.95834,80.125075,8.285742",
     "geom:latitude":8.118703,
     "geom:longitude":80.000957,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.PX.KG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898924,
-    "wof:geomhash":"81e137b1aa44f49f3a8fa8bc60236d71",
+    "wof:geomhash":"33abec9de9f3ae7040a12f2ef81cde42",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092060595,
-    "wof:lastmodified":1627522332,
+    "wof:lastmodified":1695886790,
     "wof:name":"Karuwalagaswewa",
     "wof:parent_id":85673779,
     "wof:placetype":"county",

--- a/data/109/206/064/3/1092060643.geojson
+++ b/data/109/206/064/3/1092060643.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008805,
-    "geom:area_square_m":108013632.906315,
+    "geom:area_square_m":108013632.906395,
     "geom:bbox":"79.8516651571,7.10687042921,79.9331685994,7.28042286838",
     "geom:latitude":7.195906,
     "geom:longitude":79.888874,
@@ -231,9 +231,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GQ.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898926,
-    "wof:geomhash":"44809f1fd7105bce3178bc2efa9825c2",
+    "wof:geomhash":"d5b59dd0ffd417ad78492a7e70d4e3f2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -243,7 +244,7 @@
         }
     ],
     "wof:id":1092060643,
-    "wof:lastmodified":1566595293,
+    "wof:lastmodified":1695886708,
     "wof:name":"Katana",
     "wof:parent_id":85673815,
     "wof:placetype":"county",

--- a/data/109/206/066/7/1092060667.geojson
+++ b/data/109/206/066/7/1092060667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04403,
-    "geom:area_square_m":540946215.817359,
+    "geom:area_square_m":540946148.569895,
     "geom:bbox":"81.24935,6.3686,81.609954,6.618729",
     "geom:latitude":6.497327,
     "geom:longitude":81.41074,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MJ.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898928,
-    "wof:geomhash":"23b4e9503593f30cc3a5fae263a91204",
+    "wof:geomhash":"2673ef54e9c1c7000774a9c0560b0fc0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092060667,
-    "wof:lastmodified":1627522332,
+    "wof:lastmodified":1695886790,
     "wof:name":"Katharagama",
     "wof:parent_id":85673803,
     "wof:placetype":"county",

--- a/data/109/206/068/3/1092060683.geojson
+++ b/data/109/206/068/3/1092060683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000444,
-    "geom:area_square_m":5439194.306833,
+    "geom:area_square_m":5439194.306832,
     "geom:bbox":"81.7074188483,7.67239731071,81.7437595784,7.69360047823",
     "geom:latitude":7.68142,
     "geom:longitude":81.726511,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BC.MN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898929,
-    "wof:geomhash":"0e5466c798b435f9685c9017929c3f3f",
+    "wof:geomhash":"8a5db877063784a2a6763b08eecf5997",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1092060683,
-    "wof:lastmodified":1566595310,
+    "wof:lastmodified":1695886708,
     "wof:name":"Kattankudy",
     "wof:parent_id":85673737,
     "wof:placetype":"county",

--- a/data/109/206/072/1/1092060721.geojson
+++ b/data/109/206/072/1/1092060721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008594,
-    "geom:area_square_m":105628280.165096,
+    "geom:area_square_m":105628514.106719,
     "geom:bbox":"80.646704,6.215534,80.807465,6.311062",
     "geom:latitude":6.263992,
     "geom:longitude":80.716254,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.HB.KT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898931,
-    "wof:geomhash":"c40f393ed6e4840709714b29991db89d",
+    "wof:geomhash":"4e390d44ce1fdc1f892cf7864763a407",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092060721,
-    "wof:lastmodified":1627522332,
+    "wof:lastmodified":1695886790,
     "wof:name":"Katuwana",
     "wof:parent_id":85673791,
     "wof:placetype":"county",

--- a/data/109/206/076/1/1092060761.geojson
+++ b/data/109/206/076/1/1092060761.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050473,
-    "geom:area_square_m":616893102.67607,
+    "geom:area_square_m":616893494.582684,
     "geom:bbox":"80.569805,8.549133,80.911788,8.872124",
     "geom:latitude":8.717272,
     "geom:longitude":80.709436,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898932,
-    "wof:geomhash":"4729be7bb2b29d1a536c0b6860549ac5",
+    "wof:geomhash":"e349efca5a925862d23a4f9ceb02b7de",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092060761,
-    "wof:lastmodified":1627522333,
+    "wof:lastmodified":1695886790,
     "wof:name":"Kebithigollewa",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/206/079/3/1092060793.geojson
+++ b/data/109/206/079/3/1092060793.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028275,
-    "geom:area_square_m":346172211.927879,
+    "geom:area_square_m":346172647.995532,
     "geom:bbox":"80.531655,7.900042,80.736439,8.211855",
     "geom:latitude":8.06091,
     "geom:longitude":80.624547,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898934,
-    "wof:geomhash":"402390ff3e7c2b1939ff3c4af1296b0c",
+    "wof:geomhash":"988de4fe10981a0eca63e2720ef98c42",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092060793,
-    "wof:lastmodified":1627522333,
+    "wof:lastmodified":1695886790,
     "wof:name":"Kekirawa",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/206/084/3/1092060843.geojson
+++ b/data/109/206/084/3/1092060843.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001974,
-    "geom:area_square_m":24229531.41621,
+    "geom:area_square_m":24229562.505086,
     "geom:bbox":"79.879948,6.946877,79.94,6.999336",
     "geom:latitude":6.972839,
     "geom:longitude":79.911213,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GQ.KE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898936,
-    "wof:geomhash":"f669090812d619dd7861abe385558677",
+    "wof:geomhash":"2cbbec0d13157c8e84daafa4ea294978",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1092060843,
-    "wof:lastmodified":1627522333,
+    "wof:lastmodified":1695886790,
     "wof:name":"Kelaniya",
     "wof:parent_id":85673815,
     "wof:placetype":"county",

--- a/data/109/206/088/5/1092060885.geojson
+++ b/data/109/206/088/5/1092060885.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005103,
-    "geom:area_square_m":62655619.230502,
+    "geom:area_square_m":62655648.38306,
     "geom:bbox":"79.885198,6.746444,79.967052,6.866535",
     "geom:latitude":6.804344,
     "geom:longitude":79.928296,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.CO.KE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898937,
-    "wof:geomhash":"cb2ed34ed7ca9a16222e55ed07395303",
+    "wof:geomhash":"0bf08f182bc21b9ac9e92db91bc05a1a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092060885,
-    "wof:lastmodified":1627522333,
+    "wof:lastmodified":1695886790,
     "wof:name":"Kesbewa",
     "wof:parent_id":85673811,
     "wof:placetype":"county",

--- a/data/109/206/092/5/1092060925.geojson
+++ b/data/109/206/092/5/1092060925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012434,
-    "geom:area_square_m":152084149.024799,
+    "geom:area_square_m":152084005.611659,
     "geom:bbox":"81.098462,8.366697,81.226698,8.524216",
     "geom:latitude":8.434787,
     "geom:longitude":81.162397,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.TC.KI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898938,
-    "wof:geomhash":"9566a1d919cfb080e6c83f8d9157fd46",
+    "wof:geomhash":"1b42fa8278abf56196b1def280fd4079",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092060925,
-    "wof:lastmodified":1627522333,
+    "wof:lastmodified":1695886790,
     "wof:name":"Kinniya",
     "wof:parent_id":85673747,
     "wof:placetype":"county",

--- a/data/109/206/096/9/1092060969.geojson
+++ b/data/109/206/096/9/1092060969.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006448,
-    "geom:area_square_m":79180359.252082,
+    "geom:area_square_m":79180499.568193,
     "geom:bbox":"80.198292,6.715777,80.343273,6.826575",
     "geom:latitude":6.759708,
     "geom:longitude":80.271977,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.RN.KI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898940,
-    "wof:geomhash":"351f9f1b806ee775408949cf16b75f38",
+    "wof:geomhash":"9c911cc0d928e4d575b79b71e3177358",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092060969,
-    "wof:lastmodified":1627522333,
+    "wof:lastmodified":1695886791,
     "wof:name":"Kiriella",
     "wof:parent_id":85673785,
     "wof:placetype":"county",

--- a/data/109/206/101/1/1092061011.geojson
+++ b/data/109/206/101/1/1092061011.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003655,
-    "geom:area_square_m":44938521.377065,
+    "geom:area_square_m":44938327.974983,
     "geom:bbox":"80.589123,6.004558,80.691594,6.075169",
     "geom:latitude":6.046607,
     "geom:longitude":80.63744,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MH.KP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898941,
-    "wof:geomhash":"6f18ede609ea1dca85839a90c8cfb888",
+    "wof:geomhash":"e25157c68c3eda9d45cdac9f0ad3e18c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092061011,
-    "wof:lastmodified":1627522333,
+    "wof:lastmodified":1695886791,
     "wof:name":"Kirinda Puhulwella",
     "wof:parent_id":85673795,
     "wof:placetype":"county",

--- a/data/109/206/105/7/1092061057.geojson
+++ b/data/109/206/105/7/1092061057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010747,
-    "geom:area_square_m":131694326.558183,
+    "geom:area_square_m":131694389.104805,
     "geom:bbox":"79.991413,7.623524,80.17376,7.734297",
     "geom:latitude":7.684203,
     "geom:longitude":80.100312,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898943,
-    "wof:geomhash":"6da92be2b37cb253dfcf9124c502d25c",
+    "wof:geomhash":"d12b774686b04c27db1cff40632ad9da",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092061057,
-    "wof:lastmodified":1627522333,
+    "wof:lastmodified":1695886791,
     "wof:name":"Kobeigane",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/206/108/5/1092061085.geojson
+++ b/data/109/206/108/5/1092061085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015251,
-    "geom:area_square_m":187411126.64164,
+    "geom:area_square_m":187411023.721434,
     "geom:bbox":"80.608668,6.304469,80.768708,6.459294",
     "geom:latitude":6.389634,
     "geom:longitude":80.681914,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.RN.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898944,
-    "wof:geomhash":"3a6feed4c1dfd299ec83dc2d4034f392",
+    "wof:geomhash":"460702307f126684058171c9e3754011",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092061085,
-    "wof:lastmodified":1627522333,
+    "wof:lastmodified":1695886791,
     "wof:name":"Kolonna",
     "wof:parent_id":85673785,
     "wof:placetype":"county",

--- a/data/109/206/113/3/1092061133.geojson
+++ b/data/109/206/113/3/1092061133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002095,
-    "geom:area_square_m":25720278.506433,
+    "geom:area_square_m":25720278.50643,
     "geom:bbox":"79.8739371476,6.91501590023,79.9563293392,6.95700560897",
     "geom:latitude":6.934365,
     "geom:longitude":79.913749,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"LK.CO.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898946,
-    "wof:geomhash":"be2cdd34420600cbb3ff09a360299f17",
+    "wof:geomhash":"7be2c442758bc44aa0f785febdc48681",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1092061133,
-    "wof:lastmodified":1566595313,
+    "wof:lastmodified":1695886708,
     "wof:name":"Kolonnawa",
     "wof:parent_id":85673811,
     "wof:placetype":"county",

--- a/data/109/206/117/5/1092061175.geojson
+++ b/data/109/206/117/5/1092061175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002472,
-    "geom:area_square_m":30272377.220037,
+    "geom:area_square_m":30272098.93838,
     "geom:bbox":"81.516808,7.871613,81.584587,7.94661",
     "geom:latitude":7.902667,
     "geom:longitude":81.546849,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BC.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898947,
-    "wof:geomhash":"d387c193ba1d995d68454561df3d66bd",
+    "wof:geomhash":"ce196f14d6bcb4a14bbc094f63fc9e02",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092061175,
-    "wof:lastmodified":1627522333,
+    "wof:lastmodified":1695886791,
     "wof:name":"Koralai Pattu (Valachchenai)",
     "wof:parent_id":85673737,
     "wof:placetype":"county",

--- a/data/109/206/121/7/1092061217.geojson
+++ b/data/109/206/121/7/1092061217.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001864,
-    "geom:area_square_m":22825643.584223,
+    "geom:area_square_m":22825545.260665,
     "geom:bbox":"81.324336,7.902232,81.534555,8.001397",
     "geom:latitude":7.96239,
     "geom:longitude":81.411577,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BC.KC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898949,
-    "wof:geomhash":"faf1bdf2a9674c2e18e92afe9cbeeaff",
+    "wof:geomhash":"d3b796cc9d6ef99dac4a46ac7e6c46f4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092061217,
-    "wof:lastmodified":1627522333,
+    "wof:lastmodified":1695886791,
     "wof:name":"Koralai Pattu Central",
     "wof:parent_id":85673737,
     "wof:placetype":"county",

--- a/data/109/206/125/5/1092061255.geojson
+++ b/data/109/206/125/5/1092061255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042732,
-    "geom:area_square_m":523124794.165009,
+    "geom:area_square_m":523124998.496242,
     "geom:bbox":"81.306861,7.943335,81.55542,8.267027",
     "geom:latitude":8.090772,
     "geom:longitude":81.393717,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BC.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898950,
-    "wof:geomhash":"99aef52ba38cf2dc65d78f9864675a33",
+    "wof:geomhash":"c29e9505a4d9d9dc885ba6c4611c342d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092061255,
-    "wof:lastmodified":1627522333,
+    "wof:lastmodified":1695886791,
     "wof:name":"Koralai Pattu North (Vaharai)",
     "wof:parent_id":85673737,
     "wof:placetype":"county",

--- a/data/109/206/129/9/1092061299.geojson
+++ b/data/109/206/129/9/1092061299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048819,
-    "geom:area_square_m":597978365.584508,
+    "geom:area_square_m":597978906.175212,
     "geom:bbox":"81.225877,7.76853,81.582528,7.96886",
     "geom:latitude":7.86173,
     "geom:longitude":81.375768,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BC.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898951,
-    "wof:geomhash":"7ae96dd95770f9807a762cc5409acfda",
+    "wof:geomhash":"b022d2917da738a1df0ca2c2ef882b33",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092061299,
-    "wof:lastmodified":1627522333,
+    "wof:lastmodified":1695886791,
     "wof:name":"Koralai Pattu South (Kiran)",
     "wof:parent_id":85673737,
     "wof:placetype":"county",

--- a/data/109/206/133/9/1092061339.geojson
+++ b/data/109/206/133/9/1092061339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001611,
-    "geom:area_square_m":19727176.609764,
+    "geom:area_square_m":19727221.258881,
     "geom:bbox":"81.469113,7.899638,81.530646,7.949143",
     "geom:latitude":7.923208,
     "geom:longitude":81.491952,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BC.KT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898953,
-    "wof:geomhash":"7b0ac8852506af2e0d25429ffaf48784",
+    "wof:geomhash":"8b268b19c0aa33f847d76d93296a0271",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092061339,
-    "wof:lastmodified":1627522333,
+    "wof:lastmodified":1695886791,
     "wof:name":"Koralai Pattu West (Oddamavadi)",
     "wof:parent_id":85673737,
     "wof:placetype":"county",

--- a/data/109/206/137/5/1092061375.geojson
+++ b/data/109/206/137/5/1092061375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014687,
-    "geom:area_square_m":180500694.765363,
+    "geom:area_square_m":180500903.611139,
     "geom:bbox":"80.46034,6.22837,80.625265,6.400067",
     "geom:latitude":6.32293,
     "geom:longitude":80.539799,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MH.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898954,
-    "wof:geomhash":"8c5cf185c393d40e81147ebebe924197",
+    "wof:geomhash":"c99d8c53ba8b4b0731e8ee8dd2217af7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092061375,
-    "wof:lastmodified":1627522333,
+    "wof:lastmodified":1695886791,
     "wof:name":"Kotapola",
     "wof:parent_id":85673795,
     "wof:placetype":"county",

--- a/data/109/206/140/9/1092061409.geojson
+++ b/data/109/206/140/9/1092061409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015178,
-    "geom:area_square_m":185912983.254078,
+    "geom:area_square_m":185913184.812046,
     "geom:bbox":"80.035633,7.796524,80.203723,7.9517",
     "geom:latitude":7.863465,
     "geom:longitude":80.122055,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.KT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898956,
-    "wof:geomhash":"b4f33106e575611a6c3560f5447c44f1",
+    "wof:geomhash":"4edd003fae2441f096769634b4b8f9fa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092061409,
-    "wof:lastmodified":1627522333,
+    "wof:lastmodified":1695886791,
     "wof:name":"Kotavehera",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/206/144/5/1092061445.geojson
+++ b/data/109/206/144/5/1092061445.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018057,
-    "geom:area_square_m":221598446.881061,
+    "geom:area_square_m":221598547.327123,
     "geom:bbox":"80.540043,6.967764,80.750865,7.108501",
     "geom:latitude":7.039322,
     "geom:longitude":80.656355,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.NW.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898957,
-    "wof:geomhash":"a96e64207ca56bf87859712278ac9041",
+    "wof:geomhash":"ab279b3b6fe4b37924110403f8639f66",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092061445,
-    "wof:lastmodified":1627522334,
+    "wof:lastmodified":1695886791,
     "wof:name":"Kothmale",
     "wof:parent_id":85673731,
     "wof:placetype":"county",

--- a/data/109/206/147/9/1092061479.geojson
+++ b/data/109/206/147/9/1092061479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037734,
-    "geom:area_square_m":461079833.052579,
+    "geom:area_square_m":461079526.882632,
     "geom:bbox":"80.876967,8.630804,81.218256,8.989754",
     "geom:latitude":8.814808,
     "geom:longitude":81.042382,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"LK.TC.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898959,
-    "wof:geomhash":"8afc03403e3a940b6d4bfb8a97f9bb18",
+    "wof:geomhash":"cd285961c37a651b083479376b1bfe17",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092061479,
-    "wof:lastmodified":1627522334,
+    "wof:lastmodified":1695886791,
     "wof:name":"Kuchchaveli",
     "wof:parent_id":85673747,
     "wof:placetype":"county",

--- a/data/109/206/152/5/1092061525.geojson
+++ b/data/109/206/152/5/1092061525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009211,
-    "geom:area_square_m":112926160.354176,
+    "geom:area_square_m":112926157.847217,
     "geom:bbox":"80.11647,7.388316,80.228741,7.546438",
     "geom:latitude":7.469846,
     "geom:longitude":80.169448,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.KE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898960,
-    "wof:geomhash":"45c4967e65edf60cdbb822d793946a30",
+    "wof:geomhash":"f7af1c256c886abfeba76bd3b6fe4c31",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092061525,
-    "wof:lastmodified":1627522334,
+    "wof:lastmodified":1695886791,
     "wof:name":"Kuliyapitiya East",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/206/156/9/1092061569.geojson
+++ b/data/109/206/156/9/1092061569.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013507,
-    "geom:area_square_m":165596167.490448,
+    "geom:area_square_m":165596063.323946,
     "geom:bbox":"79.986372,7.40214,80.141927,7.559746",
     "geom:latitude":7.473978,
     "geom:longitude":80.055069,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.KW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898962,
-    "wof:geomhash":"656c845b0e25811af7c884e22e37a4b1",
+    "wof:geomhash":"da8d352c8be1123ff3448146ed6964ea",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092061569,
-    "wof:lastmodified":1627522334,
+    "wof:lastmodified":1695886791,
     "wof:name":"Kuliyapitiya West",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/206/161/5/1092061615.geojson
+++ b/data/109/206/161/5/1092061615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00683,
-    "geom:area_square_m":83764406.088638,
+    "geom:area_square_m":83764264.628852,
     "geom:bbox":"80.645953,7.24989,80.755222,7.362991",
     "geom:latitude":7.304066,
     "geom:longitude":80.709367,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KY.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898963,
-    "wof:geomhash":"6daf61973b9eea6af6815141e380689e",
+    "wof:geomhash":"74cf54f606778c0996ffbf1490020a98",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092061615,
-    "wof:lastmodified":1627522334,
+    "wof:lastmodified":1695886791,
     "wof:name":"Kundasale",
     "wof:parent_id":85673719,
     "wof:placetype":"county",

--- a/data/109/206/164/9/1092061649.geojson
+++ b/data/109/206/164/9/1092061649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007425,
-    "geom:area_square_m":91026867.394354,
+    "geom:area_square_m":91026985.462495,
     "geom:bbox":"80.311969,7.397781,80.407048,7.626513",
     "geom:latitude":7.517478,
     "geom:longitude":80.35471,
@@ -187,9 +187,10 @@
         "hasc:id":"LK.KG.KU",
         "wd:id":"Q745073"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898965,
-    "wof:geomhash":"7eae2041f6fec54a68a6753a225687ed",
+    "wof:geomhash":"ef613e6ee1ac0afac6e438228567f1ff",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -199,7 +200,7 @@
         }
     ],
     "wof:id":1092061649,
-    "wof:lastmodified":1690938551,
+    "wof:lastmodified":1695886708,
     "wof:name":"Kurunegala",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/206/179/5/1092061795.geojson
+++ b/data/109/206/179/5/1092061795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014329,
-    "geom:area_square_m":175930191.782643,
+    "geom:area_square_m":175930684.026086,
     "geom:bbox":"80.275904,6.708312,80.451929,6.862681",
     "geom:latitude":6.797389,
     "geom:longitude":80.356948,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.RN.KU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898966,
-    "wof:geomhash":"4b047228677c5e075711e90d027dae45",
+    "wof:geomhash":"e1eb39afcea08b9eaf12bd68cadb9c52",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092061795,
-    "wof:lastmodified":1627522334,
+    "wof:lastmodified":1695886791,
     "wof:name":"Kuruvita",
     "wof:parent_id":85673785,
     "wof:placetype":"county",

--- a/data/109/206/181/9/1092061819.geojson
+++ b/data/109/206/181/9/1092061819.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030499,
-    "geom:area_square_m":373854544.453312,
+    "geom:area_square_m":373854339.412604,
     "geom:bbox":"80.707767,7.424815,80.899879,7.697386",
     "geom:latitude":7.554922,
     "geom:longitude":80.808765,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MT.LP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898973,
-    "wof:geomhash":"04f579580093b104d20021d440c25b67",
+    "wof:geomhash":"fb324afdd850bc0d9ed2e2f11984c386",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092061819,
-    "wof:lastmodified":1627522334,
+    "wof:lastmodified":1695886791,
     "wof:name":"Laggala-Pallegama",
     "wof:parent_id":85673723,
     "wof:placetype":"county",

--- a/data/109/206/183/1/1092061831.geojson
+++ b/data/109/206/183/1/1092061831.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.068182,
-    "geom:area_square_m":837235575.208586,
+    "geom:area_square_m":837235706.930219,
     "geom:bbox":"81.606028,6.508267,81.827888,6.993243",
     "geom:latitude":6.749052,
     "geom:longitude":81.69968,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AP.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898974,
-    "wof:geomhash":"425221579dafa40810ebf16cbac58123",
+    "wof:geomhash":"699ea48737b96c96530d7caefd80f118",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1092061831,
-    "wof:lastmodified":1627522334,
+    "wof:lastmodified":1695886791,
     "wof:name":"Lahugala",
     "wof:parent_id":85673733,
     "wof:placetype":"county",

--- a/data/109/206/185/3/1092061853.geojson
+++ b/data/109/206/185/3/1092061853.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016265,
-    "geom:area_square_m":199134871.507835,
+    "geom:area_square_m":199135075.952506,
     "geom:bbox":"81.006273,7.963158,81.187681,8.150845",
     "geom:latitude":8.056617,
     "geom:longitude":81.096144,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.PR.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898976,
-    "wof:geomhash":"ae5831cdd8a0e11bbf2f612e162bd2bf",
+    "wof:geomhash":"58e87cc1f81b61bc93e4dc64ed9c136c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092061853,
-    "wof:lastmodified":1627522334,
+    "wof:lastmodified":1695886791,
     "wof:name":"Lankapura",
     "wof:parent_id":85673743,
     "wof:placetype":"county",

--- a/data/109/206/187/7/1092061877.geojson
+++ b/data/109/206/187/7/1092061877.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011631,
-    "geom:area_square_m":142733753.878018,
+    "geom:area_square_m":142733608.999189,
     "geom:bbox":"81.106482,6.955537,81.246915,7.10636",
     "geom:latitude":7.037981,
     "geom:longitude":81.188597,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BD.LU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898977,
-    "wof:geomhash":"4be16a175a89e450695afcd8d49eeeba",
+    "wof:geomhash":"8a33038b33af8ac18c6ad3527eb7ce3a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092061877,
-    "wof:lastmodified":1627522334,
+    "wof:lastmodified":1695886791,
     "wof:name":"Lunugala",
     "wof:parent_id":85673801,
     "wof:placetype":"county",

--- a/data/109/206/190/3/1092061903.geojson
+++ b/data/109/206/190/3/1092061903.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024442,
-    "geom:area_square_m":300386647.338407,
+    "geom:area_square_m":300386822.914159,
     "geom:bbox":"81.045321,6.192084,81.30849,6.42242",
     "geom:latitude":6.331008,
     "geom:longitude":81.166586,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.HB.LU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898979,
-    "wof:geomhash":"1470a471773f6d31813c25a2029f8e61",
+    "wof:geomhash":"f2ce4c863033a202f0cda591d480fbf9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092061903,
-    "wof:lastmodified":1627522334,
+    "wof:lastmodified":1695886791,
     "wof:name":"Lunugamvehera",
     "wof:parent_id":85673791,
     "wof:placetype":"county",

--- a/data/109/206/192/9/1092061929.geojson
+++ b/data/109/206/192/9/1092061929.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007621,
-    "geom:area_square_m":93428472.03055,
+    "geom:area_square_m":93428785.586988,
     "geom:bbox":"79.808435,7.468004,79.910044,7.58659",
     "geom:latitude":7.517462,
     "geom:longitude":79.865552,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"LK.PX.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898980,
-    "wof:geomhash":"e52d877af775d05e4a811e0efeb25732",
+    "wof:geomhash":"7c6e53e0d8b32fcb38a08512ede603c2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1092061929,
-    "wof:lastmodified":1627522334,
+    "wof:lastmodified":1695886791,
     "wof:name":"Madampe",
     "wof:parent_id":85673779,
     "wof:placetype":"county",

--- a/data/109/206/197/3/1092061973.geojson
+++ b/data/109/206/197/3/1092061973.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046729,
-    "geom:area_square_m":570936612.967562,
+    "geom:area_square_m":570936590.00414,
     "geom:bbox":"80.07859,8.65716,80.401262,8.961429",
     "geom:latitude":8.84562,
     "geom:longitude":80.225593,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MB.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898982,
-    "wof:geomhash":"6e3b7f721fcd0bfa781224d4cbad48c6",
+    "wof:geomhash":"29b2f20e87570eb7ba17a9b5ef0495a0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092061973,
-    "wof:lastmodified":1627522334,
+    "wof:lastmodified":1695886791,
     "wof:name":"Madhu",
     "wof:parent_id":85673761,
     "wof:placetype":"county",

--- a/data/109/206/200/5/1092062005.geojson
+++ b/data/109/206/200/5/1092062005.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059276,
-    "geom:area_square_m":727242832.557274,
+    "geom:area_square_m":727242281.114617,
     "geom:bbox":"81.309775,6.904405,81.552494,7.458746",
     "geom:latitude":7.159191,
     "geom:longitude":81.429519,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MJ.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898983,
-    "wof:geomhash":"60ba4c1cd556bf9c788d09597c4b989d",
+    "wof:geomhash":"8ef682c70cefd49543af4a044b767182",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092062005,
-    "wof:lastmodified":1627522334,
+    "wof:lastmodified":1695886791,
     "wof:name":"Madulla",
     "wof:parent_id":85673803,
     "wof:placetype":"county",

--- a/data/109/206/203/5/1092062035.geojson
+++ b/data/109/206/203/5/1092062035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005214,
-    "geom:area_square_m":64039516.781259,
+    "geom:area_square_m":64039613.029322,
     "geom:bbox":"80.057101,6.576605,80.139304,6.723556",
     "geom:latitude":6.64894,
     "geom:longitude":80.096685,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KT.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898985,
-    "wof:geomhash":"98aede00bfa2a5bb5a9a721fd6a6763e",
+    "wof:geomhash":"1018355be955771ebe714b09281e9082",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092062035,
-    "wof:lastmodified":1627522334,
+    "wof:lastmodified":1695886791,
     "wof:name":"Madurawala",
     "wof:parent_id":85673819,
     "wof:placetype":"county",

--- a/data/109/206/209/1/1092062091.geojson
+++ b/data/109/206/209/1/1092062091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014713,
-    "geom:area_square_m":180226828.061686,
+    "geom:area_square_m":180226609.671098,
     "geom:bbox":"79.840668,7.765618,79.975102,7.973483",
     "geom:latitude":7.844967,
     "geom:longitude":79.90489,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.PX.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898987,
-    "wof:geomhash":"c7e100bbfc95fd713c4db063fa1539a2",
+    "wof:geomhash":"8e2f233b39ca2698593c025e0770f5a3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092062091,
-    "wof:lastmodified":1627522334,
+    "wof:lastmodified":1695886792,
     "wof:name":"Mahakumbukkadawala",
     "wof:parent_id":85673779,
     "wof:placetype":"county",

--- a/data/109/206/213/5/1092062135.geojson
+++ b/data/109/206/213/5/1092062135.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055051,
-    "geom:area_square_m":674788966.989265,
+    "geom:area_square_m":674789310.551899,
     "geom:bbox":"81.20682,7.356559,81.500253,7.738533",
     "geom:latitude":7.562532,
     "geom:longitude":81.349252,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AP.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898988,
-    "wof:geomhash":"d0fb57cad58ffbdf0edef5c0c3da1dbb",
+    "wof:geomhash":"58172c33be080d19d3060f4f6134b63b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092062135,
-    "wof:lastmodified":1627522335,
+    "wof:lastmodified":1695886792,
     "wof:name":"Mahaoya",
     "wof:parent_id":85673733,
     "wof:placetype":"county",

--- a/data/109/206/216/3/1092062163.geojson
+++ b/data/109/206/216/3/1092062163.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003181,
-    "geom:area_square_m":39047576.932124,
+    "geom:area_square_m":39047890.193249,
     "geom:bbox":"79.898512,6.82829,79.992551,6.885073",
     "geom:latitude":6.857175,
     "geom:longitude":79.941742,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"LK.CO.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898989,
-    "wof:geomhash":"32e501e13d75ee514a2ad77456c9291b",
+    "wof:geomhash":"54833c5599bd7c11fb710b32c46b489f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1092062163,
-    "wof:lastmodified":1627522335,
+    "wof:lastmodified":1695886792,
     "wof:name":"Maharagama",
     "wof:parent_id":85673811,
     "wof:placetype":"county",

--- a/data/109/206/220/9/1092062209.geojson
+++ b/data/109/206/220/9/1092062209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007445,
-    "geom:area_square_m":91362444.035346,
+    "geom:area_square_m":91362444.035331,
     "geom:bbox":"79.9268404143,6.98783844511,80.0924976177,7.0883537745",
     "geom:latitude":7.031057,
     "geom:longitude":80.019849,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GQ.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898991,
-    "wof:geomhash":"98a8ed0dd0581080e7f5d1a3d07f2153",
+    "wof:geomhash":"72d91a438ca8b22a0af7c98228eabe33",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092062209,
-    "wof:lastmodified":1566595285,
+    "wof:lastmodified":1695886707,
     "wof:name":"Mahara",
     "wof:parent_id":85673815,
     "wof:placetype":"county",

--- a/data/109/206/225/1/1092062251.geojson
+++ b/data/109/206/225/1/1092062251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006103,
-    "geom:area_square_m":74830787.594605,
+    "geom:area_square_m":74830256.313923,
     "geom:bbox":"79.793824,7.407608,79.920967,7.520285",
     "geom:latitude":7.45469,
     "geom:longitude":79.851159,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.PX.MW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898992,
-    "wof:geomhash":"ef8874506501d6d6a4c94df31bcc91ff",
+    "wof:geomhash":"293446419e82e5f9eb3cd3076324f5f0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092062251,
-    "wof:lastmodified":1627522335,
+    "wof:lastmodified":1695886792,
     "wof:name":"Mahawewa",
     "wof:parent_id":85673779,
     "wof:placetype":"county",

--- a/data/109/206/229/1/1092062291.geojson
+++ b/data/109/206/229/1/1092062291.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051565,
-    "geom:area_square_m":630540373.762178,
+    "geom:area_square_m":630540895.079822,
     "geom:bbox":"80.047513,8.381675,80.306148,8.681438",
     "geom:latitude":8.538771,
     "geom:longitude":80.180993,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.MV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898994,
-    "wof:geomhash":"54ecc853a633469644d4077c6b06307e",
+    "wof:geomhash":"840d96e45dd49213c6a94b364bad23df",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092062291,
-    "wof:lastmodified":1627522335,
+    "wof:lastmodified":1695886792,
     "wof:name":"Mahawilachchiya",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/206/232/9/1092062329.geojson
+++ b/data/109/206/232/9/1092062329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049374,
-    "geom:area_square_m":605382098.048228,
+    "geom:area_square_m":605382124.029069,
     "geom:bbox":"80.968792,7.235755,81.225795,7.613972",
     "geom:latitude":7.437813,
     "geom:longitude":81.082666,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BD.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898995,
-    "wof:geomhash":"bf0d1c3a2d239310a0c7552240cebc60",
+    "wof:geomhash":"36a305b0cef1eb7ff353664841917ead",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092062329,
-    "wof:lastmodified":1627522335,
+    "wof:lastmodified":1695886792,
     "wof:name":"Mahiyanganaya",
     "wof:parent_id":85673801,
     "wof:placetype":"county",

--- a/data/109/206/236/5/1092062365.geojson
+++ b/data/109/206/236/5/1092062365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021429,
-    "geom:area_square_m":262523038.423048,
+    "geom:area_square_m":262523038.423083,
     "geom:bbox":"80.1972270488,7.70271995037,80.3708422564,7.89639845247",
     "geom:latitude":7.805543,
     "geom:longitude":80.290828,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.MH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898997,
-    "wof:geomhash":"31a840c826052f34d40fb6f5895dee5e",
+    "wof:geomhash":"78a6cf13751d4f8ac26b701c331b4cb7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1092062365,
-    "wof:lastmodified":1566595308,
+    "wof:lastmodified":1695886708,
     "wof:name":"Maho",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/206/241/3/1092062413.geojson
+++ b/data/109/206/241/3/1092062413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003725,
-    "geom:area_square_m":45807832.967091,
+    "geom:area_square_m":45807671.118031,
     "geom:bbox":"80.463969,5.966699,80.534605,6.065976",
     "geom:latitude":6.020081,
     "geom:longitude":80.498296,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MH.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473898998,
-    "wof:geomhash":"13636aafac070412062dacd85b67aa27",
+    "wof:geomhash":"be0cc90ae1fd621a462201a7c2ba5e6c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092062413,
-    "wof:lastmodified":1627522335,
+    "wof:lastmodified":1695886792,
     "wof:name":"Malimbada",
     "wof:parent_id":85673795,
     "wof:placetype":"county",

--- a/data/109/206/243/7/1092062437.geojson
+++ b/data/109/206/243/7/1092062437.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006721,
-    "geom:area_square_m":82406604.519154,
+    "geom:area_square_m":82406666.08385,
     "geom:bbox":"80.352891,7.387586,80.430373,7.546798",
     "geom:latitude":7.466482,
     "geom:longitude":80.39036,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.ML"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899000,
-    "wof:geomhash":"1536315c8cbb98908cb01d9baa67d313",
+    "wof:geomhash":"946d66779cdccba24eed7ee9d31e8b70",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092062437,
-    "wof:lastmodified":1627522335,
+    "wof:lastmodified":1695886792,
     "wof:name":"Mallawapitiya",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/206/247/7/1092062477.geojson
+++ b/data/109/206/247/7/1092062477.geojson
@@ -51,6 +51,7 @@
     "wof:concordances":{
         "hasc:id":"LK.BC.MN\t"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899001,
     "wof:geomhash":"5ea7855d5046d4a0780f19a07f71dcfb",
@@ -63,7 +64,7 @@
         }
     ],
     "wof:id":1092062477,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886792,
     "wof:name":"Manmunai North",
     "wof:parent_id":85673737,
     "wof:placetype":"county",

--- a/data/109/206/251/7/1092062517.geojson
+++ b/data/109/206/251/7/1092062517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002777,
-    "geom:area_square_m":34028395.717883,
+    "geom:area_square_m":34028227.756817,
     "geom:bbox":"81.710179,7.595237,81.784762,7.681092",
     "geom:latitude":7.640038,
     "geom:longitude":81.748005,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BC.MP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899002,
-    "wof:geomhash":"7ee90ab93a34a1c9812d16160f88bc27",
+    "wof:geomhash":"40ce183f265286249dc3257b2f444647",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092062517,
-    "wof:lastmodified":1627522335,
+    "wof:lastmodified":1695886792,
     "wof:name":"Manmunai Pattu (Araipattai)",
     "wof:parent_id":85673737,
     "wof:placetype":"county",

--- a/data/109/206/255/5/1092062555.geojson
+++ b/data/109/206/255/5/1092062555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004394,
-    "geom:area_square_m":53862092.985248,
+    "geom:area_square_m":53861842.243391,
     "geom:bbox":"81.762414,7.429901,81.819588,7.600809",
     "geom:latitude":7.513533,
     "geom:longitude":81.790234,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BC.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899004,
-    "wof:geomhash":"e8ac5fcff3c8d1d94ff14b8b7247f48b",
+    "wof:geomhash":"1226242a0367af08bd716a9704b1ab2b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092062555,
-    "wof:lastmodified":1627522335,
+    "wof:lastmodified":1695886792,
     "wof:name":"Manmunai South & Eruvil pattu",
     "wof:parent_id":85673737,
     "wof:placetype":"county",

--- a/data/109/206/259/3/1092062593.geojson
+++ b/data/109/206/259/3/1092062593.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012629,
-    "geom:area_square_m":154801816.768979,
+    "geom:area_square_m":154801907.113081,
     "geom:bbox":"81.524868,7.506992,81.774586,7.651389",
     "geom:latitude":7.56847,
     "geom:longitude":81.661028,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BC.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899005,
-    "wof:geomhash":"b7c79e9fa39f6ca6c7b67b35d26b0932",
+    "wof:geomhash":"93cc448e72603f45ad550ef51ac3e4f0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092062593,
-    "wof:lastmodified":1627522335,
+    "wof:lastmodified":1695886792,
     "wof:name":"Manmunai South-West",
     "wof:parent_id":85673737,
     "wof:placetype":"county",

--- a/data/109/206/263/5/1092062635.geojson
+++ b/data/109/206/263/5/1092062635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026079,
-    "geom:area_square_m":319605203.134162,
+    "geom:area_square_m":319605010.488305,
     "geom:bbox":"81.511975,7.523172,81.711799,7.746483",
     "geom:latitude":7.638609,
     "geom:longitude":81.602357,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BC.MW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899007,
-    "wof:geomhash":"a543b8383686d8e8514786b502f2521a",
+    "wof:geomhash":"6c7ab4ffc2587b4a82d5121e551b1a0c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092062635,
-    "wof:lastmodified":1627522335,
+    "wof:lastmodified":1695886792,
     "wof:name":"Manmunai West",
     "wof:parent_id":85673737,
     "wof:placetype":"county",

--- a/data/109/206/268/3/1092062683.geojson
+++ b/data/109/206/268/3/1092062683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017464,
-    "geom:area_square_m":213288791.292651,
+    "geom:area_square_m":213289139.242411,
     "geom:bbox":"79.683746,8.838099,80.080652,9.106222",
     "geom:latitude":8.99085,
     "geom:longitude":79.887366,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MB.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899008,
-    "wof:geomhash":"c28d37561f1cacdec3b0fd344fdced49",
+    "wof:geomhash":"2f0036a8991fa5107a0e3fe2dd0e33bd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092062683,
-    "wof:lastmodified":1627522335,
+    "wof:lastmodified":1695886792,
     "wof:name":"Mannar Town",
     "wof:parent_id":85673761,
     "wof:placetype":"county",

--- a/data/109/206/271/3/1092062713.geojson
+++ b/data/109/206/271/3/1092062713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039955,
-    "geom:area_square_m":487901158.123761,
+    "geom:area_square_m":487901084.625711,
     "geom:bbox":"80.175165,8.945973,80.433636,9.213362",
     "geom:latitude":9.053019,
     "geom:longitude":80.309689,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MP.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899010,
-    "wof:geomhash":"6b900b55c6aa97735d57c09f891a8406",
+    "wof:geomhash":"5507a0112b0a0323cf3a87b18fc1aa23",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092062713,
-    "wof:lastmodified":1627522335,
+    "wof:lastmodified":1695886792,
     "wof:name":"Manthai East",
     "wof:parent_id":85673765,
     "wof:placetype":"county",

--- a/data/109/206/275/5/1092062755.geojson
+++ b/data/109/206/275/5/1092062755.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049292,
-    "geom:area_square_m":601952135.474235,
+    "geom:area_square_m":601951812.339678,
     "geom:bbox":"79.970488,8.842737,80.225482,9.233184",
     "geom:latitude":9.026695,
     "geom:longitude":80.11321,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MB.MW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899011,
-    "wof:geomhash":"5dee583dc292931dcc8ba810de990da5",
+    "wof:geomhash":"c2b4804f130cc2eabbbe8617a9e1ed6c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092062755,
-    "wof:lastmodified":1627522335,
+    "wof:lastmodified":1695886792,
     "wof:name":"Manthai West",
     "wof:parent_id":85673761,
     "wof:placetype":"county",

--- a/data/109/206/279/3/1092062793.geojson
+++ b/data/109/206/279/3/1092062793.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049002,
-    "geom:area_square_m":598200114.181855,
+    "geom:area_square_m":598200131.212093,
     "geom:bbox":"80.608878,8.969585,80.963722,9.458844",
     "geom:latitude":9.155987,
     "geom:longitude":80.797571,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MP.MP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899012,
-    "wof:geomhash":"480be60dada2fea12f9206843876cb3c",
+    "wof:geomhash":"1f8e16694f4c9cc07f0cdb2b203c2283",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092062793,
-    "wof:lastmodified":1627522336,
+    "wof:lastmodified":1695886792,
     "wof:name":"Maritimepattu",
     "wof:parent_id":85673765,
     "wof:placetype":"county",

--- a/data/109/206/282/9/1092062829.geojson
+++ b/data/109/206/282/9/1092062829.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005717,
-    "geom:area_square_m":70081299.758805,
+    "geom:area_square_m":70081141.449182,
     "geom:bbox":"80.289451,7.488098,80.369165,7.660217",
     "geom:latitude":7.557765,
     "geom:longitude":80.323868,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899014,
-    "wof:geomhash":"b40e4b0da619603a43c1b4354c5902ea",
+    "wof:geomhash":"9cde6c50fc026a86223884d8647b0159",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092062829,
-    "wof:lastmodified":1627522336,
+    "wof:lastmodified":1695886792,
     "wof:name":"Maspotha",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/206/286/9/1092062869.geojson
+++ b/data/109/206/286/9/1092062869.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006184,
-    "geom:area_square_m":75802487.7146,
+    "geom:area_square_m":75802155.478073,
     "geom:bbox":"80.593553,7.447987,80.668652,7.636472",
     "geom:latitude":7.541255,
     "geom:longitude":80.630172,
@@ -193,9 +193,10 @@
         "hasc:id":"LK.MT.MA",
         "wd:id":"Q787421"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899016,
-    "wof:geomhash":"cf4d2d2f6e935de9d7fb2c36123c86ad",
+    "wof:geomhash":"961841f7e14c3a54c87ab9a14c793889",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -205,7 +206,7 @@
         }
     ],
     "wof:id":1092062869,
-    "wof:lastmodified":1690938550,
+    "wof:lastmodified":1695886707,
     "wof:name":"Matale",
     "wof:parent_id":85673723,
     "wof:placetype":"county",

--- a/data/109/206/291/7/1092062917.geojson
+++ b/data/109/206/291/7/1092062917.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005105,
-    "geom:area_square_m":62787456.877025,
+    "geom:area_square_m":62787596.783981,
     "geom:bbox":"80.501103,5.929555,80.630103,5.99684",
     "geom:latitude":5.96169,
     "geom:longitude":80.561033,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MH.MF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899017,
-    "wof:geomhash":"33762da67db5aa231b07d3b0e04da3a3",
+    "wof:geomhash":"27c54a12f1e23fd848d876eace5ffd48",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092062917,
-    "wof:lastmodified":1627522336,
+    "wof:lastmodified":1695886792,
     "wof:name":"Matara Four Gravets",
     "wof:parent_id":85673795,
     "wof:placetype":"county",

--- a/data/109/206/295/9/1092062959.geojson
+++ b/data/109/206/295/9/1092062959.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011031,
-    "geom:area_square_m":135531245.71176,
+    "geom:area_square_m":135531240.496132,
     "geom:bbox":"80.023066,6.410326,80.153758,6.574842",
     "geom:latitude":6.4878,
     "geom:longitude":80.09059,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KT.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899018,
-    "wof:geomhash":"b2550beddd60b714bd544faacf80fb72",
+    "wof:geomhash":"ee4d11d8fa46056e9206c7ceb6021780",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092062959,
-    "wof:lastmodified":1627522336,
+    "wof:lastmodified":1695886792,
     "wof:name":"Mathugama",
     "wof:parent_id":85673819,
     "wof:placetype":"county",

--- a/data/109/206/298/7/1092062987.geojson
+++ b/data/109/206/298/7/1092062987.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009415,
-    "geom:area_square_m":115489305.381029,
+    "geom:area_square_m":115489524.914335,
     "geom:bbox":"80.389186,7.149028,80.545552,7.302846",
     "geom:latitude":7.229934,
     "geom:longitude":80.474404,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KE.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899020,
-    "wof:geomhash":"ff730f62dacedc9ec2cb62b281f3ae80",
+    "wof:geomhash":"5010493a42a18cb2210590414925d816",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1092062987,
-    "wof:lastmodified":1627522336,
+    "wof:lastmodified":1695886792,
     "wof:name":"Mawanella",
     "wof:parent_id":85673807,
     "wof:placetype":"county",

--- a/data/109/206/302/1/1092063021.geojson
+++ b/data/109/206/302/1/1092063021.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008984,
-    "geom:area_square_m":110159715.261562,
+    "geom:area_square_m":110159356.423051,
     "geom:bbox":"80.404734,7.352623,80.517707,7.517401",
     "geom:latitude":7.425575,
     "geom:longitude":80.44582,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.MW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899021,
-    "wof:geomhash":"1220e810a8929334d8bfeae260606cfe",
+    "wof:geomhash":"a41e7c7d92d721494af2783e87c21106",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092063021,
-    "wof:lastmodified":1627522336,
+    "wof:lastmodified":1695886792,
     "wof:name":"Mawathagama",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/206/306/5/1092063065.geojson
+++ b/data/109/206/306/5/1092063065.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015433,
-    "geom:area_square_m":189281276.307441,
+    "geom:area_square_m":189280937.954185,
     "geom:bbox":"80.735366,7.189752,80.858445,7.396345",
     "geom:latitude":7.302897,
     "geom:longitude":80.799786,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KY.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899028,
-    "wof:geomhash":"b48f02701eba479e4a3bc65db1ea55bd",
+    "wof:geomhash":"eaa45515ffd542645bc126145c1dfac9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092063065,
-    "wof:lastmodified":1627522336,
+    "wof:lastmodified":1695886792,
     "wof:name":"Medadumbara",
     "wof:parent_id":85673719,
     "wof:placetype":"county",

--- a/data/109/206/309/7/1092063097.geojson
+++ b/data/109/206/309/7/1092063097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019648,
-    "geom:area_square_m":241113182.036143,
+    "geom:area_square_m":241113521.486186,
     "geom:bbox":"81.225644,6.933465,81.383301,7.152323",
     "geom:latitude":7.053121,
     "geom:longitude":81.292638,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MJ.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899029,
-    "wof:geomhash":"087111dad21b5fe5e65e2d2bc7802fae",
+    "wof:geomhash":"07372a865ff5800a67f437e13b77764b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092063097,
-    "wof:lastmodified":1627522336,
+    "wof:lastmodified":1695886792,
     "wof:name":"Medagama",
     "wof:parent_id":85673803,
     "wof:placetype":"county",

--- a/data/109/206/313/9/1092063139.geojson
+++ b/data/109/206/313/9/1092063139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040397,
-    "geom:area_square_m":493915998.83929,
+    "geom:area_square_m":493915785.9526,
     "geom:bbox":"80.339608,8.49,80.641436,8.701866",
     "geom:latitude":8.588457,
     "geom:longitude":80.496665,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899031,
-    "wof:geomhash":"40fba3dd1b134d7d006b9226b5a1a981",
+    "wof:geomhash":"598be56e337762fe00dc234dc3b60794",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092063139,
-    "wof:lastmodified":1627522336,
+    "wof:lastmodified":1695886792,
     "wof:name":"Medawachchiya",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/206/318/1/1092063181.geojson
+++ b/data/109/206/318/1/1092063181.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046636,
-    "geom:area_square_m":570783651.923336,
+    "geom:area_square_m":570783626.085769,
     "geom:bbox":"80.88157,8.06484,81.209122,8.318519",
     "geom:latitude":8.184485,
     "geom:longitude":81.040263,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.PR.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899032,
-    "wof:geomhash":"cbef16a170851f2da14faa255011e3d1",
+    "wof:geomhash":"a59409a661093c108a34d8aec8db3e2d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092063181,
-    "wof:lastmodified":1627522336,
+    "wof:lastmodified":1695886793,
     "wof:name":"Medirigiriya",
     "wof:parent_id":85673743,
     "wof:placetype":"county",

--- a/data/109/206/322/3/1092063223.geojson
+++ b/data/109/206/322/3/1092063223.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008897,
-    "geom:area_square_m":109157794.946919,
+    "geom:area_square_m":109158111.43812,
     "geom:bbox":"81.026628,7.068295,81.159776,7.210416",
     "geom:latitude":7.125155,
     "geom:longitude":81.083322,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BD.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899034,
-    "wof:geomhash":"537220e0e9a63c72c834f4074b76512b",
+    "wof:geomhash":"5725be863011deec62862960d2ba00e6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092063223,
-    "wof:lastmodified":1627522336,
+    "wof:lastmodified":1695886793,
     "wof:name":"Meegahakivula",
     "wof:parent_id":85673801,
     "wof:placetype":"county",

--- a/data/109/206/325/7/1092063257.geojson
+++ b/data/109/206/325/7/1092063257.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019273,
-    "geom:area_square_m":235791052.276995,
+    "geom:area_square_m":235790971.093404,
     "geom:bbox":"80.430663,8.273006,80.660105,8.432348",
     "geom:latitude":8.350194,
     "geom:longitude":80.543354,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899035,
-    "wof:geomhash":"865126f3c458ef598ff140a701ec23fd",
+    "wof:geomhash":"b8700162010a69dadb0153e03ea198fc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092063257,
-    "wof:lastmodified":1627522336,
+    "wof:lastmodified":1695886793,
     "wof:name":"Mihinthale",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/206/329/5/1092063295.geojson
+++ b/data/109/206/329/5/1092063295.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006616,
-    "geom:area_square_m":81256625.143588,
+    "geom:area_square_m":81256626.915221,
     "geom:bbox":"79.983238,6.588511,80.0757,6.718312",
     "geom:latitude":6.658068,
     "geom:longitude":80.032532,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KT.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899036,
-    "wof:geomhash":"65791023c4da92d32d9d6c8e519cf92d",
+    "wof:geomhash":"cf08b28fdf936860bd4f1c7b3d5b06ae",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092063295,
-    "wof:lastmodified":1627522336,
+    "wof:lastmodified":1695886793,
     "wof:name":"Millaniya",
     "wof:parent_id":85673819,
     "wof:placetype":"county",

--- a/data/109/206/333/7/1092063337.geojson
+++ b/data/109/206/333/7/1092063337.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020418,
-    "geom:area_square_m":250405362.673285,
+    "geom:area_square_m":250405129.729943,
     "geom:bbox":"80.865429,7.196454,81.017836,7.491384",
     "geom:latitude":7.346576,
     "geom:longitude":80.949887,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KY.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899038,
-    "wof:geomhash":"e0e72301cb82b53ec5343cb7fd17adf2",
+    "wof:geomhash":"67cfac4944c9cf9484631625f0f75771",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092063337,
-    "wof:lastmodified":1627522336,
+    "wof:lastmodified":1695886793,
     "wof:name":"Minipe",
     "wof:parent_id":85673719,
     "wof:placetype":"county",

--- a/data/109/206/336/9/1092063369.geojson
+++ b/data/109/206/336/9/1092063369.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011386,
-    "geom:area_square_m":139699065.437663,
+    "geom:area_square_m":139699152.941094,
     "geom:bbox":"79.910602,7.093105,80.047343,7.215784",
     "geom:latitude":7.153768,
     "geom:longitude":79.977649,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GQ.MN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899039,
-    "wof:geomhash":"bedcc64a54ed56fabdc698058c39628c",
+    "wof:geomhash":"07ac598e84676d7ccb54cdf607376f5c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092063369,
-    "wof:lastmodified":1627522336,
+    "wof:lastmodified":1695886793,
     "wof:name":"Minuwangoda",
     "wof:parent_id":85673815,
     "wof:placetype":"county",

--- a/data/109/206/340/3/1092063403.geojson
+++ b/data/109/206/340/3/1092063403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015212,
-    "geom:area_square_m":186602128.453299,
+    "geom:area_square_m":186602118.200603,
     "geom:bbox":"80.037001,7.137678,80.197906,7.330748",
     "geom:latitude":7.224846,
     "geom:longitude":80.123433,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GQ.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899041,
-    "wof:geomhash":"7dffb7202576e969801f47a665c58c40",
+    "wof:geomhash":"ce9af18a69b6708d7fe56957b8d2e95d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092063403,
-    "wof:lastmodified":1627522337,
+    "wof:lastmodified":1695886793,
     "wof:name":"Mirigama",
     "wof:parent_id":85673815,
     "wof:placetype":"county",

--- a/data/109/206/344/3/1092063443.geojson
+++ b/data/109/206/344/3/1092063443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023706,
-    "geom:area_square_m":291051676.218745,
+    "geom:area_square_m":291051741.053163,
     "geom:bbox":"81.266549,6.720595,81.455819,6.957563",
     "geom:latitude":6.831408,
     "geom:longitude":81.355644,
@@ -142,9 +142,10 @@
         "hasc:id":"LK.MJ.MO",
         "wd:id":"Q923420"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899042,
-    "wof:geomhash":"dc122fb61420ddb7a5efab7439d24ea7",
+    "wof:geomhash":"c618ff6977a6659baea8b3338292c046",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1092063443,
-    "wof:lastmodified":1690938552,
+    "wof:lastmodified":1695886708,
     "wof:name":"Moneragala",
     "wof:parent_id":85673803,
     "wof:placetype":"county",

--- a/data/109/206/348/7/1092063487.geojson
+++ b/data/109/206/348/7/1092063487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001552,
-    "geom:area_square_m":19055533.796453,
+    "geom:area_square_m":19055510.494973,
     "geom:bbox":"79.866018,6.758651,79.911052,6.817603",
     "geom:latitude":6.790538,
     "geom:longitude":79.888578,
@@ -141,9 +141,10 @@
     "wof:concordances":{
         "hasc:id":"LK.CO.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899044,
-    "wof:geomhash":"6ee16c9b40f3808a57169933c3208af1",
+    "wof:geomhash":"dd6b9e0bdd3d826fe8318c77688db199",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":1092063487,
-    "wof:lastmodified":1636500557,
+    "wof:lastmodified":1695886759,
     "wof:name":"Moratuwa",
     "wof:parent_id":85673811,
     "wof:placetype":"county",

--- a/data/109/206/351/5/1092063515.geojson
+++ b/data/109/206/351/5/1092063515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027397,
-    "geom:area_square_m":334944911.231613,
+    "geom:area_square_m":334944971.436203,
     "geom:bbox":"80.888131,8.537581,81.141442,8.738136",
     "geom:latitude":8.62032,
     "geom:longitude":81.022332,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.TC.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899045,
-    "wof:geomhash":"a4f203ed0bfb33213ae7bf952cadfabd",
+    "wof:geomhash":"422cd57c636815cc35ae353a48de515f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092063515,
-    "wof:lastmodified":1627522337,
+    "wof:lastmodified":1695886793,
     "wof:name":"Morawewa",
     "wof:parent_id":85673747,
     "wof:placetype":"county",

--- a/data/109/206/356/9/1092063569.geojson
+++ b/data/109/206/356/9/1092063569.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009903,
-    "geom:area_square_m":121748713.789226,
+    "geom:area_square_m":121748714.850371,
     "geom:bbox":"80.526364,6.095785,80.660825,6.20573",
     "geom:latitude":6.146936,
     "geom:longitude":80.586368,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MH.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899047,
-    "wof:geomhash":"34aed86af942d163cf6aba1a25cbde1f",
+    "wof:geomhash":"2810f5f473da256eec457afb94be6e86",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092063569,
-    "wof:lastmodified":1627522337,
+    "wof:lastmodified":1695886793,
     "wof:name":"Mulatiyana",
     "wof:parent_id":85673795,
     "wof:placetype":"county",

--- a/data/109/206/361/3/1092063613.geojson
+++ b/data/109/206/361/3/1092063613.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019717,
-    "geom:area_square_m":241520108.80695,
+    "geom:area_square_m":241519903.065747,
     "geom:bbox":"79.746348,7.731403,79.886146,7.985956",
     "geom:latitude":7.860068,
     "geom:longitude":79.814236,
@@ -188,9 +188,10 @@
         "hasc:id":"LK.PX.MU",
         "wd:id":"Q1665318"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899048,
-    "wof:geomhash":"a56697ac0bc3bb689552e24d29376285",
+    "wof:geomhash":"0c3b6e5448b9fad18fd3a417cdf20619",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -200,7 +201,7 @@
         }
     ],
     "wof:id":1092063613,
-    "wof:lastmodified":1690938551,
+    "wof:lastmodified":1695886708,
     "wof:name":"Mundal",
     "wof:parent_id":85673779,
     "wof:placetype":"county",

--- a/data/109/206/364/7/1092063647.geojson
+++ b/data/109/206/364/7/1092063647.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03773,
-    "geom:area_square_m":461196290.371068,
+    "geom:area_square_m":461196143.205421,
     "geom:bbox":"79.919586,8.522652,80.144972,8.807074",
     "geom:latitude":8.677796,
     "geom:longitude":80.020642,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MB.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899050,
-    "wof:geomhash":"0f93df23e1ddbf8b790612be71b3c6c3",
+    "wof:geomhash":"4c6336be888c8ec3f2f9d607275206b0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092063647,
-    "wof:lastmodified":1627522337,
+    "wof:lastmodified":1695886793,
     "wof:name":"Musali",
     "wof:parent_id":85673761,
     "wof:placetype":"county",

--- a/data/109/206/368/5/1092063685.geojson
+++ b/data/109/206/368/5/1092063685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015541,
-    "geom:area_square_m":190090918.682216,
+    "geom:area_square_m":190090888.195443,
     "geom:bbox":"81.211194,8.324956,81.37263,8.522056",
     "geom:latitude":8.428065,
     "geom:longitude":81.29134,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.TC.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899051,
-    "wof:geomhash":"ac4be36885ef4c5ec640d0dd924cbd1e",
+    "wof:geomhash":"382430a182a5c966f9952f2add36ae6e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092063685,
-    "wof:lastmodified":1627522337,
+    "wof:lastmodified":1695886793,
     "wof:name":"Muttur",
     "wof:parent_id":85673747,
     "wof:placetype":"county",

--- a/data/109/206/372/9/1092063729.geojson
+++ b/data/109/206/372/9/1092063729.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009682,
-    "geom:area_square_m":118478297.627584,
+    "geom:area_square_m":118478054.815096,
     "geom:bbox":"80.337386,8.164486,80.517574,8.322481",
     "geom:latitude":8.251407,
     "geom:longitude":80.424435,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899052,
-    "wof:geomhash":"7b3e545953b001f32f12052c7b1241ea",
+    "wof:geomhash":"32033d7d44cf1e9194e9ed5bc8a8f775",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092063729,
-    "wof:lastmodified":1627522337,
+    "wof:lastmodified":1695886793,
     "wof:name":"Nachchaduwa",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/206/376/5/1092063765.geojson
+++ b/data/109/206/376/5/1092063765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014242,
-    "geom:area_square_m":175071480.744738,
+    "geom:area_square_m":175071385.515333,
     "geom:bbox":"80.236724,6.135636,80.401491,6.28722",
     "geom:latitude":6.199971,
     "geom:longitude":80.312656,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GL.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899054,
-    "wof:geomhash":"0306eaf88a1d87efc348b1e7b9845f76",
+    "wof:geomhash":"c9d8e5f8ea76b2a681d7a561e63d89da",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092063765,
-    "wof:lastmodified":1627522337,
+    "wof:lastmodified":1695886793,
     "wof:name":"Nagoda",
     "wof:parent_id":85673789,
     "wof:placetype":"county",

--- a/data/109/206/380/1/1092063801.geojson
+++ b/data/109/206/380/1/1092063801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002983,
-    "geom:area_square_m":36363862.839101,
+    "geom:area_square_m":36363939.835392,
     "geom:bbox":"80.000041,9.604584,80.137085,9.718682",
     "geom:latitude":9.667354,
     "geom:longitude":80.04892,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"LK.JA.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899055,
-    "wof:geomhash":"d5506f75b999ad00d6ea39236e13ce1b",
+    "wof:geomhash":"61be175e37323ed651e965187b6de2ad",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1092063801,
-    "wof:lastmodified":1627522337,
+    "wof:lastmodified":1695886793,
     "wof:name":"Nallur",
     "wof:parent_id":85673769,
     "wof:placetype":"county",

--- a/data/109/206/384/1/1092063841.geojson
+++ b/data/109/206/384/1/1092063841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010924,
-    "geom:area_square_m":133470112.358395,
+    "geom:area_square_m":133470212.385328,
     "geom:bbox":"79.911224,8.785819,80.097266,8.939006",
     "geom:latitude":8.834544,
     "geom:longitude":79.996882,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MB.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899057,
-    "wof:geomhash":"d9d4acde2686fafe23d689f993a436da",
+    "wof:geomhash":"226fde3c27c96c54db4aa52adafde073",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092063841,
-    "wof:lastmodified":1627522337,
+    "wof:lastmodified":1695886793,
     "wof:name":"Nanattan",
     "wof:parent_id":85673761,
     "wof:placetype":"county",

--- a/data/109/206/388/5/1092063885.geojson
+++ b/data/109/206/388/5/1092063885.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008736,
-    "geom:area_square_m":107122361.460595,
+    "geom:area_square_m":107122404.005585,
     "geom:bbox":"80.124605,7.31287,80.26366,7.480114",
     "geom:latitude":7.397428,
     "geom:longitude":80.193098,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899058,
-    "wof:geomhash":"e969f390051ae92e5803d748bf07e3f6",
+    "wof:geomhash":"d2ee2b42cea765cc46541986b0209a9d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092063885,
-    "wof:lastmodified":1627522337,
+    "wof:lastmodified":1695886793,
     "wof:name":"Narammala",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/206/391/1/1092063911.geojson
+++ b/data/109/206/391/1/1092063911.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006188,
-    "geom:area_square_m":75879509.753617,
+    "geom:area_square_m":75879614.955697,
     "geom:bbox":"79.81775,7.355125,79.930316,7.434665",
     "geom:latitude":7.396269,
     "geom:longitude":79.874581,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.PX.NT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899060,
-    "wof:geomhash":"5e4aec5caac40d8e9a3e6c85d635ce94",
+    "wof:geomhash":"f989f3d280b6ed55c3bf2af064085a82",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092063911,
-    "wof:lastmodified":1627522337,
+    "wof:lastmodified":1695886793,
     "wof:name":"Nattandiya",
     "wof:parent_id":85673779,
     "wof:placetype":"county",

--- a/data/109/206/394/9/1092063949.geojson
+++ b/data/109/206/394/9/1092063949.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02336,
-    "geom:area_square_m":286253851.050661,
+    "geom:area_square_m":286253940.144542,
     "geom:bbox":"80.614923,7.596346,80.792798,7.803306",
     "geom:latitude":7.68739,
     "geom:longitude":80.707674,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MT.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899061,
-    "wof:geomhash":"691eb2a1d33abdae38829f577ffa0e93",
+    "wof:geomhash":"8083379cff36f0ecefdd1433315a5c45",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092063949,
-    "wof:lastmodified":1627522337,
+    "wof:lastmodified":1695886793,
     "wof:name":"Naula",
     "wof:parent_id":85673723,
     "wof:placetype":"county",

--- a/data/109/206/398/5/1092063985.geojson
+++ b/data/109/206/398/5/1092063985.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006681,
-    "geom:area_square_m":81919644.632998,
+    "geom:area_square_m":81919774.848054,
     "geom:bbox":"81.712494,7.362491,81.826442,7.478883",
     "geom:latitude":7.418021,
     "geom:longitude":81.76738,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AP.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899063,
-    "wof:geomhash":"227d414caba1b365585088f0bb0d6f2b",
+    "wof:geomhash":"51b958f366ecbab50e2584896eecff37",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092063985,
-    "wof:lastmodified":1627522337,
+    "wof:lastmodified":1695886793,
     "wof:name":"Navithanveli",
     "wof:parent_id":85673733,
     "wof:placetype":"county",

--- a/data/109/206/402/5/1092064025.geojson
+++ b/data/109/206/402/5/1092064025.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013938,
-    "geom:area_square_m":170661655.3941,
+    "geom:area_square_m":170661475.764884,
     "geom:bbox":"80.001561,7.936648,80.15397,8.081116",
     "geom:latitude":8.012382,
     "geom:longitude":80.088804,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.PX.NW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899064,
-    "wof:geomhash":"8d6d41a4e84071ae73dd1a31507ddaf2",
+    "wof:geomhash":"5f622fc032f2c9e8ca51d812060bcf71",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092064025,
-    "wof:lastmodified":1627522337,
+    "wof:lastmodified":1695886793,
     "wof:name":"Nawagattegama",
     "wof:parent_id":85673779,
     "wof:placetype":"county",

--- a/data/109/206/405/3/1092064053.geojson
+++ b/data/109/206/405/3/1092064053.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002278,
-    "geom:area_square_m":27946061.542191,
+    "geom:area_square_m":27946061.542192,
     "geom:bbox":"79.816802979,7.10958951722,79.8632946799,7.27167536396",
     "geom:latitude":7.208399,
     "geom:longitude":79.843286,
@@ -150,9 +150,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GQ.NE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899066,
-    "wof:geomhash":"d35a4deaa55f414a92295c23bce3cd31",
+    "wof:geomhash":"7d96a57c786ac59d8342d56d8dc93de0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":1092064053,
-    "wof:lastmodified":1566595308,
+    "wof:lastmodified":1695886708,
     "wof:name":"Negombo",
     "wof:parent_id":85673815,
     "wof:placetype":"county",

--- a/data/109/206/409/7/1092064097.geojson
+++ b/data/109/206/409/7/1092064097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012549,
-    "geom:area_square_m":154210579.873267,
+    "geom:area_square_m":154210601.369829,
     "geom:bbox":"80.316766,6.280561,80.496828,6.427912",
     "geom:latitude":6.360346,
     "geom:longitude":80.410378,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GL.NE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899067,
-    "wof:geomhash":"14b1a5cbbcbd759de37f513b9fc9df8f",
+    "wof:geomhash":"8a39040ef5a89bbf3ea05109c13bd626",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092064097,
-    "wof:lastmodified":1627522337,
+    "wof:lastmodified":1695886793,
     "wof:name":"Neluwa",
     "wof:parent_id":85673789,
     "wof:placetype":"county",

--- a/data/109/206/413/7/1092064137.geojson
+++ b/data/109/206/413/7/1092064137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012392,
-    "geom:area_square_m":151830510.833588,
+    "geom:area_square_m":151830816.809355,
     "geom:bbox":"80.054673,7.716098,80.241815,7.823356",
     "geom:latitude":7.76333,
     "geom:longitude":80.146826,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.NI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899068,
-    "wof:geomhash":"d5964dbe664089a397a412140123b36c",
+    "wof:geomhash":"ad9f6d21a868376c0d87b386515ee7f0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092064137,
-    "wof:lastmodified":1627522337,
+    "wof:lastmodified":1695886793,
     "wof:name":"Nikaweratiya",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/206/415/5/1092064155.geojson
+++ b/data/109/206/415/5/1092064155.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002641,
-    "geom:area_square_m":32386598.532819,
+    "geom:area_square_m":32386662.599386,
     "geom:bbox":"81.817563,7.299618,81.868752,7.364454",
     "geom:latitude":7.330358,
     "geom:longitude":81.841491,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AP.NI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899070,
-    "wof:geomhash":"aaaaa43377b2017dc4a77b23deb65d5e",
+    "wof:geomhash":"7a5c679e6c4919e449c4f7475034dad7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092064155,
-    "wof:lastmodified":1627522338,
+    "wof:lastmodified":1695886793,
     "wof:name":"Ninthavur",
     "wof:parent_id":85673733,
     "wof:placetype":"county",

--- a/data/109/206/419/7/1092064197.geojson
+++ b/data/109/206/419/7/1092064197.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012883,
-    "geom:area_square_m":158256213.898608,
+    "geom:area_square_m":158256519.336571,
     "geom:bbox":"80.369466,6.477592,80.524823,6.641532",
     "geom:latitude":6.570573,
     "geom:longitude":80.457466,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.RN.NI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899071,
-    "wof:geomhash":"607661e4303e2285c0164e769e5df207",
+    "wof:geomhash":"a046789e0c174eb42bea0d2cc6cac9db",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092064197,
-    "wof:lastmodified":1627522338,
+    "wof:lastmodified":1695886793,
     "wof:name":"Nivithigala",
     "wof:parent_id":85673785,
     "wof:placetype":"county",

--- a/data/109/206/424/1/1092064241.geojson
+++ b/data/109/206/424/1/1092064241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008456,
-    "geom:area_square_m":103925494.928565,
+    "geom:area_square_m":103925497.954769,
     "geom:bbox":"80.20636,6.200639,80.304722,6.382106",
     "geom:latitude":6.30296,
     "geom:longitude":80.252499,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GL.NI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899073,
-    "wof:geomhash":"92ab46257102331728402908845ab057",
+    "wof:geomhash":"8b71808d45e8d4b302ef8ef5b3415937",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092064241,
-    "wof:lastmodified":1627522338,
+    "wof:lastmodified":1695886793,
     "wof:name":"Niyagama",
     "wof:parent_id":85673789,
     "wof:placetype":"county",

--- a/data/109/206/427/9/1092064279.geojson
+++ b/data/109/206/427/9/1092064279.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069365,
-    "geom:area_square_m":848655575.829792,
+    "geom:area_square_m":848655615.65321,
     "geom:bbox":"79.951692,8.176809,80.324992,8.524043",
     "geom:latitude":8.331361,
     "geom:longitude":80.125268,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.NO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899074,
-    "wof:geomhash":"9c141c37f69c186933ed2d70603c15f6",
+    "wof:geomhash":"e41feb3456e72a6ff02c6f6925948b56",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092064279,
-    "wof:lastmodified":1627522338,
+    "wof:lastmodified":1695886793,
     "wof:name":"Nochchiyagama",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/206/431/3/1092064313.geojson
+++ b/data/109/206/431/3/1092064313.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039545,
-    "geom:area_square_m":485437313.65875,
+    "geom:area_square_m":485437307.463833,
     "geom:bbox":"80.576625,6.772883,80.861684,7.023229",
     "geom:latitude":6.906734,
     "geom:longitude":80.731965,
@@ -193,9 +193,10 @@
         "hasc:id":"LK.NW.NE",
         "wd:id":"Q1583950"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899076,
-    "wof:geomhash":"0053070100d3dfb19fd3d6599092235b",
+    "wof:geomhash":"a2b85f4984fea66be247aa7ac16f29b9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -205,7 +206,7 @@
         }
     ],
     "wof:id":1092064313,
-    "wof:lastmodified":1690938550,
+    "wof:lastmodified":1695886707,
     "wof:name":"Nuwara Eliya",
     "wof:parent_id":85673731,
     "wof:placetype":"county",

--- a/data/109/206/435/3/1092064353.geojson
+++ b/data/109/206/435/3/1092064353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032245,
-    "geom:area_square_m":394424232.187355,
+    "geom:area_square_m":394424144.529788,
     "geom:bbox":"80.268513,8.277763,80.462842,8.5609",
     "geom:latitude":8.415366,
     "geom:longitude":80.352809,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.NC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899077,
-    "wof:geomhash":"af135960dca6f677cabc2a2335677e9c",
+    "wof:geomhash":"61a67e722f5dfdef60f0d127041412d6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092064353,
-    "wof:lastmodified":1627522338,
+    "wof:lastmodified":1695886793,
     "wof:name":"Nuwaragam Palatha Central",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/206/439/3/1092064393.geojson
+++ b/data/109/206/439/3/1092064393.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007538,
-    "geom:area_square_m":92229359.884145,
+    "geom:area_square_m":92229226.351268,
     "geom:bbox":"80.357016,8.263119,80.504608,8.356188",
     "geom:latitude":8.308599,
     "geom:longitude":80.446854,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.NE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899078,
-    "wof:geomhash":"b48d85b4751854cb51f21b7a9735c00f",
+    "wof:geomhash":"a08d62956890fa3ab9cfd1b4d66edb84",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092064393,
-    "wof:lastmodified":1627522338,
+    "wof:lastmodified":1695886793,
     "wof:name":"Nuwaragam Palatha East",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/206/442/1/1092064421.geojson
+++ b/data/109/206/442/1/1092064421.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054127,
-    "geom:area_square_m":660709191.283533,
+    "geom:area_square_m":660709285.975913,
     "geom:bbox":"80.339232,9.030094,80.750576,9.3472",
     "geom:latitude":9.187351,
     "geom:longitude":80.53136,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MP.OD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899080,
-    "wof:geomhash":"685f8f961be26ab06f4a1d2c5aeb4342",
+    "wof:geomhash":"ce5ce1e9cd6eaeaf025f855ae6c1ccd3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092064421,
-    "wof:lastmodified":1627522338,
+    "wof:lastmodified":1695886793,
     "wof:name":"Oddusuddan",
     "wof:parent_id":85673765,
     "wof:placetype":"county",

--- a/data/109/206/446/3/1092064463.geojson
+++ b/data/109/206/446/3/1092064463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003577,
-    "geom:area_square_m":43973469.157147,
+    "geom:area_square_m":43973353.609044,
     "geom:bbox":"80.647767,6.095397,80.731938,6.168086",
     "geom:latitude":6.131203,
     "geom:longitude":80.692768,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.HB.OK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899081,
-    "wof:geomhash":"72e1090417b220ec4dcb2655b9890c60",
+    "wof:geomhash":"93f99e499d633a1f7ba70cd6591ec69a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092064463,
-    "wof:lastmodified":1627522338,
+    "wof:lastmodified":1695886793,
     "wof:name":"Okewela",
     "wof:parent_id":85673791,
     "wof:placetype":"county",

--- a/data/109/206/450/5/1092064505.geojson
+++ b/data/109/206/450/5/1092064505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006326,
-    "geom:area_square_m":77704569.605847,
+    "geom:area_square_m":77704532.614142,
     "geom:bbox":"80.577179,6.548943,80.675836,6.662294",
     "geom:latitude":6.611981,
     "geom:longitude":80.626974,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.RN.OP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899083,
-    "wof:geomhash":"ecca162a4f82e99f900ed467613b69d8",
+    "wof:geomhash":"9f31aca57983d956aaff3cd7370cdeaa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092064505,
-    "wof:lastmodified":1627522338,
+    "wof:lastmodified":1695886793,
     "wof:name":"Opanayake",
     "wof:parent_id":85673785,
     "wof:placetype":"county",

--- a/data/109/206/454/3/1092064543.geojson
+++ b/data/109/206/454/3/1092064543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014957,
-    "geom:area_square_m":182360855.095866,
+    "geom:area_square_m":182360838.41542,
     "geom:bbox":"80.257168,9.512055,80.458217,9.680803",
     "geom:latitude":9.589218,
     "geom:longitude":80.359103,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KL.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899084,
-    "wof:geomhash":"cd39b82f922cd82be3df6fd811eacf0a",
+    "wof:geomhash":"d63e7ff2ada468f2f49f57ccccddcdbf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092064543,
-    "wof:lastmodified":1627522338,
+    "wof:lastmodified":1695886793,
     "wof:name":"Pachchilaipalli",
     "wof:parent_id":85673773,
     "wof:placetype":"county",

--- a/data/109/206/458/3/1092064583.geojson
+++ b/data/109/206/458/3/1092064583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008652,
-    "geom:area_square_m":105688822.414951,
+    "geom:area_square_m":105688701.376675,
     "geom:bbox":"80.756156,8.836813,80.932207,8.966746",
     "geom:latitude":8.915296,
     "geom:longitude":80.853083,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.TC.PS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899086,
-    "wof:geomhash":"fa720092bc60a1421e73256bb37fb734",
+    "wof:geomhash":"a72a43279598fc622f88dd8116cfe10d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092064583,
-    "wof:lastmodified":1627522338,
+    "wof:lastmodified":1695886794,
     "wof:name":"Padavi Sri Pura",
     "wof:parent_id":85673747,
     "wof:placetype":"county",

--- a/data/109/206/461/9/1092064619.geojson
+++ b/data/109/206/461/9/1092064619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019969,
-    "geom:area_square_m":243982685.474018,
+    "geom:area_square_m":243982671.471432,
     "geom:bbox":"80.671058,8.775907,80.907211,8.921778",
     "geom:latitude":8.853477,
     "geom:longitude":80.783872,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.PD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899088,
-    "wof:geomhash":"51653994125557a28826e6b76b450c73",
+    "wof:geomhash":"370021142c5a2f74e83d1b15d6a7f785",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092064619,
-    "wof:lastmodified":1627522338,
+    "wof:lastmodified":1695886794,
     "wof:name":"Padaviya",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/206/465/9/1092064659.geojson
+++ b/data/109/206/465/9/1092064659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032379,
-    "geom:area_square_m":397010949.148726,
+    "geom:area_square_m":397011461.13634,
     "geom:bbox":"81.184823,7.244158,81.363256,7.604899",
     "geom:latitude":7.427012,
     "geom:longitude":81.261964,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AP.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899089,
-    "wof:geomhash":"5e0f4c006480aa288d59d49acd0e8ed8",
+    "wof:geomhash":"12d787c35e1d26b5f745c03dca5d6221",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092064659,
-    "wof:lastmodified":1627522338,
+    "wof:lastmodified":1695886794,
     "wof:name":"Padiyathalawa",
     "wof:parent_id":85673733,
     "wof:placetype":"county",

--- a/data/109/206/469/3/1092064693.geojson
+++ b/data/109/206/469/3/1092064693.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008556,
-    "geom:area_square_m":105042900.477011,
+    "geom:area_square_m":105043093.985224,
     "geom:bbox":"80.039872,6.769923,80.203363,6.888059",
     "geom:latitude":6.834352,
     "geom:longitude":80.122963,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.CO.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899090,
-    "wof:geomhash":"4e6d46c55fc8334f52b2b2aca08a042a",
+    "wof:geomhash":"ff99da4d5554912155a41af93d7c3201",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092064693,
-    "wof:lastmodified":1627522338,
+    "wof:lastmodified":1695886794,
     "wof:name":"Padukka",
     "wof:parent_id":85673811,
     "wof:placetype":"county",

--- a/data/109/206/473/3/1092064733.geojson
+++ b/data/109/206/473/3/1092064733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008934,
-    "geom:area_square_m":109515939.034184,
+    "geom:area_square_m":109515969.652065,
     "geom:bbox":"80.073517,7.495449,80.221155,7.617861",
     "geom:latitude":7.559274,
     "geom:longitude":80.14193,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899092,
-    "wof:geomhash":"0a12b404203ad9286eca5ecf2d0f0ebc",
+    "wof:geomhash":"f676c995e87e22ec180e48dc3f2d7075",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092064733,
-    "wof:lastmodified":1627522338,
+    "wof:lastmodified":1695886794,
     "wof:name":"Paduwasnuwara East",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/206/477/1/1092064771.geojson
+++ b/data/109/206/477/1/1092064771.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014149,
-    "geom:area_square_m":173418999.255219,
+    "geom:area_square_m":173419126.098329,
     "geom:bbox":"79.99811,7.486851,80.194745,7.678813",
     "geom:latitude":7.600363,
     "geom:longitude":80.077154,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.PD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899093,
-    "wof:geomhash":"c79168d7390b25b33a75f3089101fca8",
+    "wof:geomhash":"d2410666c3b582c2c82b532e7324434d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092064771,
-    "wof:lastmodified":1627522339,
+    "wof:lastmodified":1695886794,
     "wof:name":"Paduwasnuwara West",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/206/479/3/1092064793.geojson
+++ b/data/109/206/479/3/1092064793.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018553,
-    "geom:area_square_m":227226297.178774,
+    "geom:area_square_m":227226324.326281,
     "geom:bbox":"80.459788,7.817885,80.633971,8.003878",
     "geom:latitude":7.906471,
     "geom:longitude":80.537922,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.PL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899095,
-    "wof:geomhash":"d4ae45483b9bef8defc4fd51227038fc",
+    "wof:geomhash":"bf44063ffd9fa3a88df002ff145d7d93",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092064793,
-    "wof:lastmodified":1627522339,
+    "wof:lastmodified":1695886794,
     "wof:name":"Palagala",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/206/483/1/1092064831.geojson
+++ b/data/109/206/483/1/1092064831.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022983,
-    "geom:area_square_m":282361976.037744,
+    "geom:area_square_m":282361794.25712,
     "geom:bbox":"80.168192,6.397388,80.380548,6.62295",
     "geom:latitude":6.50534,
     "geom:longitude":80.274773,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KT.PL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899096,
-    "wof:geomhash":"e4729ad2f2bf2cd76b9f2f651f91b723",
+    "wof:geomhash":"377dce3dbce6b1220513b55386db6489",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092064831,
-    "wof:lastmodified":1627522339,
+    "wof:lastmodified":1695886794,
     "wof:name":"Palindanuwara",
     "wof:parent_id":85673819,
     "wof:placetype":"county",

--- a/data/109/206/486/7/1092064867.geojson
+++ b/data/109/206/486/7/1092064867.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009362,
-    "geom:area_square_m":114714696.996401,
+    "geom:area_square_m":114714757.212671,
     "geom:bbox":"79.860309,7.624148,80.001295,7.783984",
     "geom:latitude":7.727702,
     "geom:longitude":79.931432,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.PX.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899098,
-    "wof:geomhash":"ad5a3804a67ede3b3b0f696bccdf811c",
+    "wof:geomhash":"2f8653385a307b7f8c4614d6c8ff5127",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092064867,
-    "wof:lastmodified":1627522339,
+    "wof:lastmodified":1695886794,
     "wof:name":"Pallama",
     "wof:parent_id":85673779,
     "wof:placetype":"county",

--- a/data/109/206/490/7/1092064907.geojson
+++ b/data/109/206/490/7/1092064907.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00656,
-    "geom:area_square_m":80398519.752196,
+    "geom:area_square_m":80398641.898504,
     "geom:bbox":"80.54633,7.584518,80.646714,7.708671",
     "geom:latitude":7.646444,
     "geom:longitude":80.598317,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MT.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899099,
-    "wof:geomhash":"1217db94bbc837a9440927950f5736a4",
+    "wof:geomhash":"a23d1324faba641149ceb9c0bee7b804",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092064907,
-    "wof:lastmodified":1627522339,
+    "wof:lastmodified":1695886794,
     "wof:name":"Pallepola",
     "wof:parent_id":85673723,
     "wof:placetype":"county",

--- a/data/109/206/494/5/1092064945.geojson
+++ b/data/109/206/494/5/1092064945.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016256,
-    "geom:area_square_m":199019004.758623,
+    "geom:area_square_m":199018771.835113,
     "geom:bbox":"80.654341,7.956662,80.790324,8.230862",
     "geom:latitude":8.080274,
     "geom:longitude":80.719896,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.PS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899101,
-    "wof:geomhash":"7799724af4bd2ac21928b9321203d094",
+    "wof:geomhash":"571f41429525985a1972bfb6c12bac7b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092064945,
-    "wof:lastmodified":1627522339,
+    "wof:lastmodified":1695886794,
     "wof:name":"Palugaswewa",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/206/498/7/1092064987.geojson
+++ b/data/109/206/498/7/1092064987.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004758,
-    "geom:area_square_m":58429558.517939,
+    "geom:area_square_m":58429506.030187,
     "geom:bbox":"79.878959,6.64697,79.955867,6.773583",
     "geom:latitude":6.715905,
     "geom:longitude":79.918633,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KT.PN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899102,
-    "wof:geomhash":"cd081dbf29b6b3f61a4bb7d4b97d4d15",
+    "wof:geomhash":"dfa9da98a5b77bd973d6d160c53ab783",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1092064987,
-    "wof:lastmodified":1627522339,
+    "wof:lastmodified":1695886794,
     "wof:name":"Panadura",
     "wof:parent_id":85673819,
     "wof:placetype":"county",

--- a/data/109/206/503/5/1092065035.geojson
+++ b/data/109/206/503/5/1092065035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023522,
-    "geom:area_square_m":288454054.643409,
+    "geom:area_square_m":288454124.584188,
     "geom:bbox":"79.92646,7.283031,80.160969,7.432257",
     "geom:latitude":7.362954,
     "geom:longitude":80.03182,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.PL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899104,
-    "wof:geomhash":"e8ef26a7f78768155a9558fc09ed5bd0",
+    "wof:geomhash":"331ad81f960eef5473a5a5ecd652713c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092065035,
-    "wof:lastmodified":1627522339,
+    "wof:lastmodified":1695886794,
     "wof:name":"Pannala",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/206/506/1/1092065061.geojson
+++ b/data/109/206/506/1/1092065061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00759,
-    "geom:area_square_m":93065716.08095,
+    "geom:area_square_m":93065750.372259,
     "geom:bbox":"80.685593,7.348049,80.809438,7.473331",
     "geom:latitude":7.410427,
     "geom:longitude":80.741091,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KY.PV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899105,
-    "wof:geomhash":"1f75725f85737c3f0550cff16534c82c",
+    "wof:geomhash":"158de70ea355b22c0f14a7579504b5ae",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092065061,
-    "wof:lastmodified":1627522339,
+    "wof:lastmodified":1695886794,
     "wof:name":"Panvila",
     "wof:parent_id":85673719,
     "wof:placetype":"county",

--- a/data/109/206/510/5/1092065105.geojson
+++ b/data/109/206/510/5/1092065105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010269,
-    "geom:area_square_m":126031543.930919,
+    "geom:area_square_m":126031490.036635,
     "geom:bbox":"80.457976,6.939025,80.602157,7.092589",
     "geom:latitude":7.018041,
     "geom:longitude":80.537638,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KY.PK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899107,
-    "wof:geomhash":"593ac6a45c90a4ba6d30910ea4f945a0",
+    "wof:geomhash":"b8ee0811436665e33794c3257959ed03",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092065105,
-    "wof:lastmodified":1627522339,
+    "wof:lastmodified":1695886794,
     "wof:name":"Pasbage Korale",
     "wof:parent_id":85673719,
     "wof:placetype":"county",

--- a/data/109/206/515/9/1092065159.geojson
+++ b/data/109/206/515/9/1092065159.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012529,
-    "geom:area_square_m":153992545.44372,
+    "geom:area_square_m":153992407.423213,
     "geom:bbox":"80.542507,6.18755,80.673396,6.353991",
     "geom:latitude":6.276026,
     "geom:longitude":80.60851,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MH.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899108,
-    "wof:geomhash":"ac516da233d7bfab21d9d2da863f331e",
+    "wof:geomhash":"4212dba01831de7104222a537cb6b797",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092065159,
-    "wof:lastmodified":1627522339,
+    "wof:lastmodified":1695886794,
     "wof:name":"Pasgoda",
     "wof:parent_id":85673795,
     "wof:placetype":"county",

--- a/data/109/206/518/1/1092065181.geojson
+++ b/data/109/206/518/1/1092065181.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011001,
-    "geom:area_square_m":135030051.019296,
+    "geom:area_square_m":135029970.583802,
     "geom:bbox":"81.089711,6.876284,81.220515,7.079593",
     "geom:latitude":6.965293,
     "geom:longitude":81.147181,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BD.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899110,
-    "wof:geomhash":"57e40aa21b8b207afa67e601d1643b1c",
+    "wof:geomhash":"6205009f44b9697df5375ede861b7bf5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092065181,
-    "wof:lastmodified":1627522339,
+    "wof:lastmodified":1695886794,
     "wof:name":"Passara",
     "wof:parent_id":85673801,
     "wof:placetype":"county",

--- a/data/109/206/521/9/1092065219.geojson
+++ b/data/109/206/521/9/1092065219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004055,
-    "geom:area_square_m":49726367.61849,
+    "geom:area_square_m":49726241.824174,
     "geom:bbox":"80.612875,7.308267,80.697851,7.39",
     "geom:latitude":7.348757,
     "geom:longitude":80.660866,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KY.PD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899111,
-    "wof:geomhash":"b66ad9432430151efb5011b0cff06629",
+    "wof:geomhash":"cc179cc2a57ca7f6a39689cc1900b2c2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092065219,
-    "wof:lastmodified":1627522339,
+    "wof:lastmodified":1695886794,
     "wof:name":"Pathadumbara",
     "wof:parent_id":85673719,
     "wof:placetype":"county",

--- a/data/109/206/526/3/1092065263.geojson
+++ b/data/109/206/526/3/1092065263.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007313,
-    "geom:area_square_m":89703647.49364,
+    "geom:area_square_m":89703555.486958,
     "geom:bbox":"80.62415,7.182179,80.772575,7.267935",
     "geom:latitude":7.230852,
     "geom:longitude":80.706178,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KY.PH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899113,
-    "wof:geomhash":"073cd403a31121db67cc33c058975809",
+    "wof:geomhash":"32f94bdb55afab9c6e879d92b21898b7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092065263,
-    "wof:lastmodified":1627522339,
+    "wof:lastmodified":1695886794,
     "wof:name":"Pathahewaheta",
     "wof:parent_id":85673719,
     "wof:placetype":"county",

--- a/data/109/206/530/3/1092065303.geojson
+++ b/data/109/206/530/3/1092065303.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011765,
-    "geom:area_square_m":144503344.395028,
+    "geom:area_square_m":144503159.129027,
     "geom:bbox":"80.400198,6.574908,80.606528,6.700859",
     "geom:latitude":6.636353,
     "geom:longitude":80.510251,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.RN.PE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899114,
-    "wof:geomhash":"85a8d1faec7c6f2564b2f06ef20f013e",
+    "wof:geomhash":"e8d59eb0ef384f212ccda38a777e16f8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092065303,
-    "wof:lastmodified":1627522339,
+    "wof:lastmodified":1695886794,
     "wof:name":"Pelmadulla",
     "wof:parent_id":85673785,
     "wof:placetype":"county",

--- a/data/109/206/534/3/1092065343.geojson
+++ b/data/109/206/534/3/1092065343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011025,
-    "geom:area_square_m":135514174.599011,
+    "geom:area_square_m":135514216.280619,
     "geom:bbox":"80.375544,6.159163,80.554766,6.335005",
     "geom:latitude":6.239713,
     "geom:longitude":80.473039,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MH.PI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899116,
-    "wof:geomhash":"866b3dd042afc498e05d76ae6b8db634",
+    "wof:geomhash":"4f6952ab4c0d559ec7d65cab1f9db210",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092065343,
-    "wof:lastmodified":1627522339,
+    "wof:lastmodified":1695886794,
     "wof:name":"Pitabeddara",
     "wof:parent_id":85673795,
     "wof:placetype":"county",

--- a/data/109/206/538/1/1092065381.geojson
+++ b/data/109/206/538/1/1092065381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007945,
-    "geom:area_square_m":97434399.860873,
+    "geom:area_square_m":97434200.909164,
     "geom:bbox":"80.262361,7.316618,80.357239,7.439746",
     "geom:latitude":7.374871,
     "geom:longitude":80.310467,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.PH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899117,
-    "wof:geomhash":"439b94fa3f21085e151f4840c7711b4b",
+    "wof:geomhash":"9c6df412fb93585c7f10f7338eacb46a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092065381,
-    "wof:lastmodified":1627522340,
+    "wof:lastmodified":1695886794,
     "wof:name":"Polgahawela",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/206/542/1/1092065421.geojson
+++ b/data/109/206/542/1/1092065421.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034222,
-    "geom:area_square_m":419237372.790796,
+    "geom:area_square_m":419237672.974927,
     "geom:bbox":"80.33164,7.675541,80.54,7.965959",
     "geom:latitude":7.803271,
     "geom:longitude":80.427927,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.PP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899119,
-    "wof:geomhash":"34d4967741ece9901033583d22d1e9c8",
+    "wof:geomhash":"ef6abe42e0483fa21a97efeca11b9a0a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092065421,
-    "wof:lastmodified":1627522340,
+    "wof:lastmodified":1695886794,
     "wof:name":"Polpithigama",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/206/544/3/1092065443.geojson
+++ b/data/109/206/544/3/1092065443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046131,
-    "geom:area_square_m":562787916.644127,
+    "geom:area_square_m":562787916.6442,
     "geom:bbox":"79.971221924,9.20771409763,80.3192051943,9.609611511",
     "geom:latitude":9.38377,
     "geom:longitude":80.181704,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KL.PO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899120,
-    "wof:geomhash":"763aeca6a6d95fe44973728a6676f81e",
+    "wof:geomhash":"827803e94295b6927cd195aa95d71a03",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092065443,
-    "wof:lastmodified":1566595297,
+    "wof:lastmodified":1695886708,
     "wof:name":"Poonakary",
     "wof:parent_id":85673773,
     "wof:placetype":"county",

--- a/data/109/206/548/5/1092065485.geojson
+++ b/data/109/206/548/5/1092065485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014507,
-    "geom:area_square_m":177848723.349405,
+    "geom:area_square_m":177848956.883948,
     "geom:bbox":"81.640452,7.406238,81.784015,7.573104",
     "geom:latitude":7.50083,
     "geom:longitude":81.710016,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BC.PP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899122,
-    "wof:geomhash":"5e7fcdb2dc5855e7d8c9a6de5885e0d7",
+    "wof:geomhash":"b3cf2bf9092e670abe9b80280b188c4f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092065485,
-    "wof:lastmodified":1627522340,
+    "wof:lastmodified":1695886794,
     "wof:name":"Poratheevu Pattu",
     "wof:parent_id":85673737,
     "wof:placetype":"county",

--- a/data/109/206/552/5/1092065525.geojson
+++ b/data/109/206/552/5/1092065525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022823,
-    "geom:area_square_m":280148098.36766,
+    "geom:area_square_m":280148009.483371,
     "geom:bbox":"81.709784,6.808621,81.880386,7.04563",
     "geom:latitude":6.940382,
     "geom:longitude":81.800106,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AP.PO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899123,
-    "wof:geomhash":"af30558fc1bed5f42b1f3af3b170c03e",
+    "wof:geomhash":"e453a273df3bac0359c479fba703bbd2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1092065525,
-    "wof:lastmodified":1627522340,
+    "wof:lastmodified":1695886794,
     "wof:name":"Pottuvil",
     "wof:parent_id":85673733,
     "wof:placetype":"county",

--- a/data/109/206/554/7/1092065547.geojson
+++ b/data/109/206/554/7/1092065547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004825,
-    "geom:area_square_m":59170481.331095,
+    "geom:area_square_m":59170476.094911,
     "geom:bbox":"80.516554,7.349326,80.615753,7.459986",
     "geom:latitude":7.400896,
     "geom:longitude":80.566164,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KY.PO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899124,
-    "wof:geomhash":"7973eb5260df66de1abea85e4a91b199",
+    "wof:geomhash":"d17b96081d3a82fc79ea361b30be9b5d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092065547,
-    "wof:lastmodified":1627522340,
+    "wof:lastmodified":1695886794,
     "wof:name":"Pujapitiya",
     "wof:parent_id":85673719,
     "wof:placetype":"county",

--- a/data/109/206/558/3/1092065583.geojson
+++ b/data/109/206/558/3/1092065583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036293,
-    "geom:area_square_m":442863347.620742,
+    "geom:area_square_m":442863331.019151,
     "geom:bbox":"80.497633,9.197499,80.747194,9.430945",
     "geom:latitude":9.307828,
     "geom:longitude":80.616787,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MP.PU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899126,
-    "wof:geomhash":"f495dd226796cf1ade58e710dfded236",
+    "wof:geomhash":"0ebdb01c75b2278160f0c9e3f7feeed7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092065583,
-    "wof:lastmodified":1627522340,
+    "wof:lastmodified":1695886794,
     "wof:name":"Puthukudiyiruppu",
     "wof:parent_id":85673765,
     "wof:placetype":"county",

--- a/data/109/206/561/7/1092065617.geojson
+++ b/data/109/206/561/7/1092065617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01491,
-    "geom:area_square_m":182560192.565879,
+    "geom:area_square_m":182560194.934119,
     "geom:bbox":"79.78875,7.930742,79.923073,8.111785",
     "geom:latitude":8.025122,
     "geom:longitude":79.863732,
@@ -187,9 +187,10 @@
         "hasc:id":"LK.PX.PU",
         "wd:id":"Q1665318"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899127,
-    "wof:geomhash":"22687ac482d00b0fae363668592fae2d",
+    "wof:geomhash":"1d020dcc9a21c1b5d4139c008e289473",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -199,7 +200,7 @@
         }
     ],
     "wof:id":1092065617,
-    "wof:lastmodified":1690938549,
+    "wof:lastmodified":1695886707,
     "wof:name":"Puttalam",
     "wof:parent_id":85673779,
     "wof:placetype":"county",

--- a/data/109/206/566/3/1092065663.geojson
+++ b/data/109/206/566/3/1092065663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008354,
-    "geom:area_square_m":102243425.186884,
+    "geom:area_square_m":102243499.811112,
     "geom:bbox":"80.082101,8.113901,80.278157,8.236809",
     "geom:latitude":8.181907,
     "geom:longitude":80.184942,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.RJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899129,
-    "wof:geomhash":"6b7677add9220715a6c8eb6bab62f2cb",
+    "wof:geomhash":"ab626018bcec9aed04fc0dbb3fa50ee4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092065663,
-    "wof:lastmodified":1627522340,
+    "wof:lastmodified":1695886794,
     "wof:name":"Rajanganaya",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/206/568/7/1092065687.geojson
+++ b/data/109/206/568/7/1092065687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024688,
-    "geom:area_square_m":301939614.793894,
+    "geom:area_square_m":301939870.281933,
     "geom:bbox":"80.393451,8.394484,80.680964,8.587699",
     "geom:latitude":8.47642,
     "geom:longitude":80.551809,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.RB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899130,
-    "wof:geomhash":"7b5479b3b4c75effd392010866134960",
+    "wof:geomhash":"b39b55a79af65b41f73ce6d704fa98df",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092065687,
-    "wof:lastmodified":1627522340,
+    "wof:lastmodified":1695886794,
     "wof:name":"Rambewa",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/206/572/9/1092065729.geojson
+++ b/data/109/206/572/9/1092065729.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011224,
-    "geom:area_square_m":137660209.88956,
+    "geom:area_square_m":137660296.584999,
     "geom:bbox":"80.311203,7.241311,80.462266,7.396812",
     "geom:latitude":7.32233,
     "geom:longitude":80.386556,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KE.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899131,
-    "wof:geomhash":"ca22e57d4bb264d2cc5f46a6af115b9b",
+    "wof:geomhash":"d72086f1af93620995a0e18bb18c484f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092065729,
-    "wof:lastmodified":1627522340,
+    "wof:lastmodified":1695886794,
     "wof:name":"Rambukkana",
     "wof:parent_id":85673807,
     "wof:placetype":"county",

--- a/data/109/206/576/7/1092065767.geojson
+++ b/data/109/206/576/7/1092065767.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010123,
-    "geom:area_square_m":124026912.221287,
+    "geom:area_square_m":124026767.692755,
     "geom:bbox":"79.948966,7.684415,80.090465,7.841043",
     "geom:latitude":7.763679,
     "geom:longitude":80.024479,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899133,
-    "wof:geomhash":"f5308479885d412e0eb35d9769e2e2e6",
+    "wof:geomhash":"b7dff0da4c5e4c47cc4ca2c8b87ae74c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092065767,
-    "wof:lastmodified":1627522340,
+    "wof:lastmodified":1695886794,
     "wof:name":"Rasnayakapura",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/206/580/1/1092065801.geojson
+++ b/data/109/206/580/1/1092065801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00118,
-    "geom:area_square_m":14488804.811861,
+    "geom:area_square_m":14488946.71035,
     "geom:bbox":"79.858719,6.804488,79.898544,6.847923",
     "geom:latitude":6.826952,
     "geom:longitude":79.876628,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.CO.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899134,
-    "wof:geomhash":"54e4722fe88e00e7857a4bae03ea3fa7",
+    "wof:geomhash":"451ebd77ebe72af83ed98c8858fcd19b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092065801,
-    "wof:lastmodified":1627522340,
+    "wof:lastmodified":1695886794,
     "wof:name":"Rathmalana",
     "wof:parent_id":85673811,
     "wof:placetype":"county",

--- a/data/109/206/583/9/1092065839.geojson
+++ b/data/109/206/583/9/1092065839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026364,
-    "geom:area_square_m":323743852.892101,
+    "geom:area_square_m":323743641.525856,
     "geom:bbox":"80.351283,6.657858,80.616236,6.833171",
     "geom:latitude":6.731051,
     "geom:longitude":80.485534,
@@ -196,9 +196,10 @@
         "hasc:id":"LK.RN.RA",
         "wd:id":"Q1587175"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899136,
-    "wof:geomhash":"84b6b91beba5a21bc14d318f7a6b05eb",
+    "wof:geomhash":"633ac96d335b171279682b8fae30e6c6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -208,7 +209,7 @@
         }
     ],
     "wof:id":1092065839,
-    "wof:lastmodified":1690938551,
+    "wof:lastmodified":1695886760,
     "wof:name":"Ratnapura",
     "wof:parent_id":85673785,
     "wof:placetype":"county",

--- a/data/109/206/588/5/1092065885.geojson
+++ b/data/109/206/588/5/1092065885.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008608,
-    "geom:area_square_m":105534363.286469,
+    "geom:area_square_m":105534357.867727,
     "geom:bbox":"80.632007,7.421633,80.740438,7.55081",
     "geom:latitude":7.486113,
     "geom:longitude":80.686537,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MT.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899137,
-    "wof:geomhash":"82c72feb46270fd0d3efb74f5692a83a",
+    "wof:geomhash":"126f857a1876438cb4c3b9b2109f9a83",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1092065885,
-    "wof:lastmodified":1627522340,
+    "wof:lastmodified":1695886794,
     "wof:name":"Rattota",
     "wof:parent_id":85673723,
     "wof:placetype":"county",

--- a/data/109/206/592/9/1092065929.geojson
+++ b/data/109/206/592/9/1092065929.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035661,
-    "geom:area_square_m":437405049.888202,
+    "geom:area_square_m":437404785.437836,
     "geom:bbox":"81.017761,7.150788,81.272934,7.412859",
     "geom:latitude":7.274063,
     "geom:longitude":81.129272,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BD.RI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899139,
-    "wof:geomhash":"09c7797b4cc6a4883c3f7a6e7c222a91",
+    "wof:geomhash":"7b1b9c86607228cdf1a9ffd4696e6b70",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092065929,
-    "wof:lastmodified":1627522340,
+    "wof:lastmodified":1695886794,
     "wof:name":"Rideemaliyadda",
     "wof:parent_id":85673801,
     "wof:placetype":"county",

--- a/data/109/206/595/1/1092065951.geojson
+++ b/data/109/206/595/1/1092065951.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018304,
-    "geom:area_square_m":224389188.416952,
+    "geom:area_square_m":224389149.483718,
     "geom:bbox":"80.440102,7.411461,80.577423,7.634206",
     "geom:latitude":7.516787,
     "geom:longitude":80.519099,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.RI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899140,
-    "wof:geomhash":"4c08f0a9f8e88a9efff5b8800b1eb093",
+    "wof:geomhash":"4b8e0e097e1d91108dea390d25aef017",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092065951,
-    "wof:lastmodified":1627522340,
+    "wof:lastmodified":1695886795,
     "wof:name":"Ridigama",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/206/599/3/1092065993.geojson
+++ b/data/109/206/599/3/1092065993.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011409,
-    "geom:area_square_m":140000968.38189,
+    "geom:area_square_m":140001068.770685,
     "geom:bbox":"80.165006,6.976227,80.284019,7.157577",
     "geom:latitude":7.063486,
     "geom:longitude":80.218854,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KE.RU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899141,
-    "wof:geomhash":"fe45f0989c3b5c95ed2649806487d0c1",
+    "wof:geomhash":"00e9aa1149ab84a4a0e05be075ec59bf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092065993,
-    "wof:lastmodified":1627522340,
+    "wof:lastmodified":1695886795,
     "wof:name":"Ruwanwella",
     "wof:parent_id":85673807,
     "wof:placetype":"county",

--- a/data/109/206/603/3/1092066033.geojson
+++ b/data/109/206/603/3/1092066033.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000323,
-    "geom:area_square_m":3956831.55923,
+    "geom:area_square_m":3956927.99073,
     "geom:bbox":"81.820549,7.372783,81.844377,7.393702",
     "geom:latitude":7.383953,
     "geom:longitude":81.831206,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AP.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899143,
-    "wof:geomhash":"dcb85e3e0e9e85e475bb319be73cf4d3",
+    "wof:geomhash":"ff4c8557fdf150ae89a755e32a45aa84",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066033,
-    "wof:lastmodified":1627522340,
+    "wof:lastmodified":1695886795,
     "wof:name":"Sainthamarathu",
     "wof:parent_id":85673733,
     "wof:placetype":"county",

--- a/data/109/206/606/7/1092066067.geojson
+++ b/data/109/206/606/7/1092066067.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008771,
-    "geom:area_square_m":107569725.618848,
+    "geom:area_square_m":107569764.626142,
     "geom:bbox":"81.697583,7.268005,81.822583,7.386895",
     "geom:latitude":7.327556,
     "geom:longitude":81.764641,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AP.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899144,
-    "wof:geomhash":"96dfc38f4a023b10a8818cea513fd9e9",
+    "wof:geomhash":"d20faa9cd3599129acf692d87d2b4227",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092066067,
-    "wof:lastmodified":1627522341,
+    "wof:lastmodified":1695886795,
     "wof:name":"Sammanthurai",
     "wof:parent_id":85673733,
     "wof:placetype":"county",

--- a/data/109/206/610/9/1092066109.geojson
+++ b/data/109/206/610/9/1092066109.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012,
-    "geom:area_square_m":147305157.59733,
+    "geom:area_square_m":147305595.946713,
     "geom:bbox":"80.066678,6.858486,80.223043,6.978828",
     "geom:latitude":6.922499,
     "geom:longitude":80.147546,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.CO.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899146,
-    "wof:geomhash":"35ef10e5ef97eca324358fabc14daedc",
+    "wof:geomhash":"3fa13eebe751c55397be2760ac1b42f5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066109,
-    "wof:lastmodified":1627522341,
+    "wof:lastmodified":1695886795,
     "wof:name":"Seethawaka",
     "wof:parent_id":85673811,
     "wof:placetype":"county",

--- a/data/109/206/613/3/1092066133.geojson
+++ b/data/109/206/613/3/1092066133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022739,
-    "geom:area_square_m":278222975.793224,
+    "geom:area_square_m":278222780.517248,
     "geom:bbox":"81.162016,8.149927,81.369436,8.410407",
     "geom:latitude":8.29963,
     "geom:longitude":81.252634,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.TC.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899147,
-    "wof:geomhash":"7b9c24c27269020a9a491342228a893f",
+    "wof:geomhash":"793b89e273592e326f572bd2c9d04614",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066133,
-    "wof:lastmodified":1627522341,
+    "wof:lastmodified":1695886795,
     "wof:name":"Seruvila",
     "wof:parent_id":85673747,
     "wof:placetype":"county",

--- a/data/109/206/617/5/1092066175.geojson
+++ b/data/109/206/617/5/1092066175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015779,
-    "geom:area_square_m":193908892.237183,
+    "geom:area_square_m":193908582.990581,
     "geom:bbox":"80.841364,6.297704,81.021496,6.445085",
     "geom:latitude":6.37834,
     "geom:longitude":80.933347,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MJ.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899149,
-    "wof:geomhash":"37c87b1db7f1089aa3c3c7cca63f1635",
+    "wof:geomhash":"08077f72ec1d468575123b9bead332f8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066175,
-    "wof:lastmodified":1627522341,
+    "wof:lastmodified":1695886795,
     "wof:name":"Sevanagala",
     "wof:parent_id":85673803,
     "wof:placetype":"county",

--- a/data/109/206/620/3/1092066203.geojson
+++ b/data/109/206/620/3/1092066203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087481,
-    "geom:area_square_m":1073994672.941078,
+    "geom:area_square_m":1073995035.250527,
     "geom:bbox":"81.368879,6.589349,81.636608,7.171551",
     "geom:latitude":6.85104,
     "geom:longitude":81.526975,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MJ.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899150,
-    "wof:geomhash":"eb0d96eb2fd97fb42967585e66d01ca2",
+    "wof:geomhash":"d25d2a551f689bb915d2847f50ebddbf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066203,
-    "wof:lastmodified":1627522341,
+    "wof:lastmodified":1695886795,
     "wof:name":"Siyambalanduwa",
     "wof:parent_id":85673803,
     "wof:placetype":"county",

--- a/data/109/206/624/5/1092066245.geojson
+++ b/data/109/206/624/5/1092066245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01549,
-    "geom:area_square_m":190380529.45209,
+    "geom:area_square_m":190380794.222781,
     "geom:bbox":"80.92282,6.189901,81.081232,6.396842",
     "geom:latitude":6.292376,
     "geom:longitude":81.013928,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.HB.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899151,
-    "wof:geomhash":"78accb40ea789a4df1f729843b3c04d6",
+    "wof:geomhash":"e36abe9e900d85fef9d1bed122e16ad0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092066245,
-    "wof:lastmodified":1627522341,
+    "wof:lastmodified":1695886795,
     "wof:name":"Sooriyawewa",
     "wof:parent_id":85673791,
     "wof:placetype":"county",

--- a/data/109/206/628/5/1092066285.geojson
+++ b/data/109/206/628/5/1092066285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006695,
-    "geom:area_square_m":82158714.917821,
+    "geom:area_square_m":82158495.428938,
     "geom:bbox":"80.998087,6.997651,81.103872,7.089512",
     "geom:latitude":7.045235,
     "geom:longitude":81.049291,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BD.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899153,
-    "wof:geomhash":"baf6cd43283d6fd84396cd92d3e8e1f9",
+    "wof:geomhash":"f8d9c7742b949710d8dbb4598c297fbe",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066285,
-    "wof:lastmodified":1627522341,
+    "wof:lastmodified":1695886795,
     "wof:name":"Soranathota",
     "wof:parent_id":85673801,
     "wof:placetype":"county",

--- a/data/109/206/631/9/1092066319.geojson
+++ b/data/109/206/631/9/1092066319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00115,
-    "geom:area_square_m":14115820.69889,
+    "geom:area_square_m":14115658.29979,
     "geom:bbox":"79.881488,6.866215,79.920091,6.920399",
     "geom:latitude":6.892784,
     "geom:longitude":79.897135,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.CO.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899154,
-    "wof:geomhash":"084f33acb2077e76af064fcc3f4f9c4c",
+    "wof:geomhash":"37ab141225832cb63dfe4bab591af607",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066319,
-    "wof:lastmodified":1627522341,
+    "wof:lastmodified":1695886795,
     "wof:name":"Sri Jayawardanapura Kotte",
     "wof:parent_id":85673811,
     "wof:placetype":"county",

--- a/data/109/206/635/5/1092066355.geojson
+++ b/data/109/206/635/5/1092066355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013185,
-    "geom:area_square_m":162122603.778041,
+    "geom:area_square_m":162122603.778018,
     "geom:bbox":"80.7132156607,5.969583511,80.9336877896,6.1365021482",
     "geom:latitude":6.069729,
     "geom:longitude":80.825697,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"LK.HB.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899156,
-    "wof:geomhash":"9950de894b07abf9ea0048902f76b3e1",
+    "wof:geomhash":"05e7fe41a234970de140cb3ae549dc9f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1092066355,
-    "wof:lastmodified":1566595292,
+    "wof:lastmodified":1695886707,
     "wof:name":"Tangalle",
     "wof:parent_id":85673791,
     "wof:placetype":"county",

--- a/data/109/206/639/5/1092066395.geojson
+++ b/data/109/206/639/5/1092066395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017896,
-    "geom:area_square_m":219036338.848193,
+    "geom:area_square_m":219036295.282641,
     "geom:bbox":"80.279242,8.083902,80.46708,8.300699",
     "geom:latitude":8.185371,
     "geom:longitude":80.375951,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.TL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899157,
-    "wof:geomhash":"244cfbf7182c3563667d7be81c4e56a6",
+    "wof:geomhash":"633ee46883b6ebdb188e9311a37270eb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066395,
-    "wof:lastmodified":1627522341,
+    "wof:lastmodified":1695886795,
     "wof:name":"Thalawa",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/206/643/7/1092066437.geojson
+++ b/data/109/206/643/7/1092066437.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036385,
-    "geom:area_square_m":445668257.064397,
+    "geom:area_square_m":445668515.718097,
     "geom:bbox":"80.885496,7.708871,81.122065,8.013645",
     "geom:latitude":7.873694,
     "geom:longitude":80.98845,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.PR.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899159,
-    "wof:geomhash":"0e687c668cfff4d0f1ea2dc1c7511e0c",
+    "wof:geomhash":"81c9093c8a2c139e7277c6a6554d8baa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066437,
-    "wof:lastmodified":1627522341,
+    "wof:lastmodified":1695886795,
     "wof:name":"Thamankaduwa",
     "wof:parent_id":85673743,
     "wof:placetype":"county",

--- a/data/109/206/646/3/1092066463.geojson
+++ b/data/109/206/646/3/1092066463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019788,
-    "geom:area_square_m":241994863.256316,
+    "geom:area_square_m":241994825.165231,
     "geom:bbox":"80.947334,8.406159,81.141389,8.572771",
     "geom:latitude":8.49289,
     "geom:longitude":81.050324,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.TC.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899160,
-    "wof:geomhash":"6d4db1814a8bb9fef14c5136c93b8d70",
+    "wof:geomhash":"6dc5e71401f004ff7f36514389678612",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066463,
-    "wof:lastmodified":1627522341,
+    "wof:lastmodified":1695886795,
     "wof:name":"Thambalagamuwa",
     "wof:parent_id":85673747,
     "wof:placetype":"county",

--- a/data/109/206/650/3/1092066503.geojson
+++ b/data/109/206/650/3/1092066503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00883,
-    "geom:area_square_m":108083602.063351,
+    "geom:area_square_m":108083511.901321,
     "geom:bbox":"80.256554,8.073594,80.387653,8.225966",
     "geom:latitude":8.154608,
     "geom:longitude":80.317039,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.TB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899161,
-    "wof:geomhash":"4165421d19e5ab18dd9f4d7f7296c0f2",
+    "wof:geomhash":"847decbc96991e0d735eb51113f72e63",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066503,
-    "wof:lastmodified":1627522341,
+    "wof:lastmodified":1695886795,
     "wof:name":"Thambuttegama",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/206/653/7/1092066537.geojson
+++ b/data/109/206/653/7/1092066537.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054089,
-    "geom:area_square_m":664527342.221151,
+    "geom:area_square_m":664527474.0223,
     "geom:bbox":"80.829088,6.340568,81.287894,6.690863",
     "geom:latitude":6.494177,
     "geom:longitude":81.013981,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MJ.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899163,
-    "wof:geomhash":"d3d3fe0dde1c556265c26c2ec3c420b7",
+    "wof:geomhash":"4bfc9cad1c5a78c177ae2996103ee5d1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066537,
-    "wof:lastmodified":1627522341,
+    "wof:lastmodified":1695886795,
     "wof:name":"Thanamalvila",
     "wof:parent_id":85673803,
     "wof:placetype":"county",

--- a/data/109/206/657/3/1092066573.geojson
+++ b/data/109/206/657/3/1092066573.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014147,
-    "geom:area_square_m":173876647.648811,
+    "geom:area_square_m":173876727.668346,
     "geom:bbox":"80.289959,6.213635,80.440858,6.398527",
     "geom:latitude":6.292735,
     "geom:longitude":80.355979,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GL.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899164,
-    "wof:geomhash":"d2c905b565b93d08fab6e957a2913383",
+    "wof:geomhash":"52c39ba1f9d61fffdbeb5b56590a744b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066573,
-    "wof:lastmodified":1627522341,
+    "wof:lastmodified":1695886795,
     "wof:name":"Thawalama",
     "wof:parent_id":85673789,
     "wof:placetype":"county",

--- a/data/109/206/661/1/1092066611.geojson
+++ b/data/109/206/661/1/1092066611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018863,
-    "geom:area_square_m":229926812.357995,
+    "geom:area_square_m":229926770.581232,
     "geom:bbox":"80.073323,9.605389,80.299576,9.761118",
     "geom:latitude":9.678222,
     "geom:longitude":80.191558,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.JA.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899166,
-    "wof:geomhash":"ea51398cb9b9482a55d59d1f7350f9b4",
+    "wof:geomhash":"f20141ae60a6bac15893e515ad5c3335",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066611,
-    "wof:lastmodified":1627522341,
+    "wof:lastmodified":1695886795,
     "wof:name":"Thenmaradchy (Chavakachcheri)",
     "wof:parent_id":85673769,
     "wof:placetype":"county",

--- a/data/109/206/665/7/1092066657.geojson
+++ b/data/109/206/665/7/1092066657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004068,
-    "geom:area_square_m":50029399.071298,
+    "geom:area_square_m":50029427.55164,
     "geom:bbox":"80.51733,5.969972,80.611119,6.04675",
     "geom:latitude":6.011034,
     "geom:longitude":80.562015,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MH.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899168,
-    "wof:geomhash":"27a1dce5a5455b0e2841b32073cd56f4",
+    "wof:geomhash":"ab142c82e657aa4d8cf10c13d47eab2f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066657,
-    "wof:lastmodified":1627522341,
+    "wof:lastmodified":1695886795,
     "wof:name":"Thihagoda",
     "wof:parent_id":85673795,
     "wof:placetype":"county",

--- a/data/109/206/670/1/1092066701.geojson
+++ b/data/109/206/670/1/1092066701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001827,
-    "geom:area_square_m":22426908.101534,
+    "geom:area_square_m":22426934.523213,
     "geom:bbox":"79.845413,6.861385,79.889463,6.933513",
     "geom:latitude":6.898067,
     "geom:longitude":79.868802,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.CO.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899169,
-    "wof:geomhash":"884be24381d374ab08397c33eabf0b45",
+    "wof:geomhash":"6ff30542a88ec1533401b224edc47c8a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066701,
-    "wof:lastmodified":1627522342,
+    "wof:lastmodified":1695886795,
     "wof:name":"Thimbirigasyaya",
     "wof:parent_id":85673811,
     "wof:placetype":"county",

--- a/data/109/206/673/9/1092066739.geojson
+++ b/data/109/206/673/9/1092066739.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022942,
-    "geom:area_square_m":280780272.663287,
+    "geom:area_square_m":280780029.142743,
     "geom:bbox":"80.43708,8.108934,80.66236,8.305684",
     "geom:latitude":8.203572,
     "geom:longitude":80.557021,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AD.TP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899171,
-    "wof:geomhash":"340845473b52824aa7b1191a1691711b",
+    "wof:geomhash":"073d4516bd98dd3d43418242ef19cb54",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066739,
-    "wof:lastmodified":1627522342,
+    "wof:lastmodified":1695886795,
     "wof:name":"Thirappane",
     "wof:parent_id":85673751,
     "wof:placetype":"county",

--- a/data/109/206/677/3/1092066773.geojson
+++ b/data/109/206/677/3/1092066773.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021324,
-    "geom:area_square_m":261667490.156812,
+    "geom:area_square_m":261667333.534814,
     "geom:bbox":"81.671777,6.969709,81.876442,7.193279",
     "geom:latitude":7.072528,
     "geom:longitude":81.770055,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AP.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899172,
-    "wof:geomhash":"02b91031deffd52edd0750f513b7ae13",
+    "wof:geomhash":"26ad03dfa8b380d3830e68560e1ed22b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092066773,
-    "wof:lastmodified":1627522342,
+    "wof:lastmodified":1695886795,
     "wof:name":"Thirukkovil",
     "wof:parent_id":85673733,
     "wof:placetype":"county",

--- a/data/109/206/680/9/1092066809.geojson
+++ b/data/109/206/680/9/1092066809.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003967,
-    "geom:area_square_m":48643447.711565,
+    "geom:area_square_m":48643380.262591,
     "geom:bbox":"80.466083,7.330253,80.565114,7.409602",
     "geom:latitude":7.366724,
     "geom:longitude":80.513315,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KY.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899174,
-    "wof:geomhash":"661a90de8c031b529acb9a5d5fdbfd46",
+    "wof:geomhash":"6eaa621b35980b887c3e72fea00f925b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066809,
-    "wof:lastmodified":1627522342,
+    "wof:lastmodified":1695886795,
     "wof:name":"Thumpane",
     "wof:parent_id":85673719,
     "wof:placetype":"county",

--- a/data/109/206/683/3/1092066833.geojson
+++ b/data/109/206/683/3/1092066833.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026614,
-    "geom:area_square_m":324832507.136522,
+    "geom:area_square_m":324832900.270236,
     "geom:bbox":"80.19,9.094048,80.411545,9.309991",
     "geom:latitude":9.220335,
     "geom:longitude":80.286597,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MP.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899175,
-    "wof:geomhash":"0fceb0a662530bce0692f7c30f41d0ea",
+    "wof:geomhash":"6db25562993d029ed2ebd6e4633182f2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066833,
-    "wof:lastmodified":1627522342,
+    "wof:lastmodified":1695886795,
     "wof:name":"Thunukkai",
     "wof:parent_id":85673765,
     "wof:placetype":"county",

--- a/data/109/206/686/9/1092066869.geojson
+++ b/data/109/206/686/9/1092066869.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065984,
-    "geom:area_square_m":810851310.083419,
+    "geom:area_square_m":810851174.738598,
     "geom:bbox":"81.217459,6.19125,81.709587,6.576289",
     "geom:latitude":6.379537,
     "geom:longitude":81.456205,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"LK.HB.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899177,
-    "wof:geomhash":"3b99624c82d0c8a78ca5212b624e3a6e",
+    "wof:geomhash":"9f9eb96fac3c2d4ca0687cd78069be17",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092066869,
-    "wof:lastmodified":1627522342,
+    "wof:lastmodified":1695886795,
     "wof:name":"Tissamaharama",
     "wof:parent_id":85673791,
     "wof:placetype":"county",

--- a/data/109/206/690/7/1092066907.geojson
+++ b/data/109/206/690/7/1092066907.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012262,
-    "geom:area_square_m":149920245.723712,
+    "geom:area_square_m":149920581.81798,
     "geom:bbox":"81.109945,8.502889,81.24958,8.660849",
     "geom:latitude":8.578484,
     "geom:longitude":81.176396,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.TC.TT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899178,
-    "wof:geomhash":"91f32dc9e7915ae33cc7039af8576f30",
+    "wof:geomhash":"49168cccd6f6fc31b4e7840f1f8918da",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066907,
-    "wof:lastmodified":1627522342,
+    "wof:lastmodified":1695886795,
     "wof:name":"Trincomalee Town and Gravets",
     "wof:parent_id":85673747,
     "wof:placetype":"county",

--- a/data/109/206/693/5/1092066935.geojson
+++ b/data/109/206/693/5/1092066935.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022841,
-    "geom:area_square_m":280123694.801018,
+    "geom:area_square_m":280123719.098469,
     "geom:bbox":"80.788164,7.188846,80.94966,7.474806",
     "geom:latitude":7.3287,
     "geom:longitude":80.875027,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KY.UD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899180,
-    "wof:geomhash":"1801d748f0f53511b0a0dc92b6e2d397",
+    "wof:geomhash":"d408f8260f31daa47dace701d5d1b9dc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066935,
-    "wof:lastmodified":1627522342,
+    "wof:lastmodified":1695886795,
     "wof:name":"Udadumbara",
     "wof:parent_id":85673719,
     "wof:placetype":"county",

--- a/data/109/206/696/7/1092066967.geojson
+++ b/data/109/206/696/7/1092066967.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007424,
-    "geom:area_square_m":91095240.605577,
+    "geom:area_square_m":91095055.740005,
     "geom:bbox":"80.529766,7.073742,80.662396,7.191836",
     "geom:latitude":7.12765,
     "geom:longitude":80.597213,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KY.UP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899181,
-    "wof:geomhash":"0c64cfbad2d9d2c2a42715b2878ee9f8",
+    "wof:geomhash":"fe7a16ae7ce3f8eec019ae61bc6b1e30",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066967,
-    "wof:lastmodified":1627522342,
+    "wof:lastmodified":1695886795,
     "wof:name":"Udapalatha",
     "wof:parent_id":85673719,
     "wof:placetype":"county",

--- a/data/109/206/698/9/1092066989.geojson
+++ b/data/109/206/698/9/1092066989.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009409,
-    "geom:area_square_m":115355477.99242,
+    "geom:area_square_m":115355460.29138,
     "geom:bbox":"79.899324,7.407189,79.995234,7.560347",
     "geom:latitude":7.47968,
     "geom:longitude":79.946789,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.UD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899182,
-    "wof:geomhash":"16bf36b16cbd92f1fbcd1589210474ea",
+    "wof:geomhash":"fa113ba63218870cf2d85a02a24cf0e3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066989,
-    "wof:lastmodified":1627522342,
+    "wof:lastmodified":1695886795,
     "wof:name":"Udubaddawa",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/206/699/1/1092066991.geojson
+++ b/data/109/206/699/1/1092066991.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00553,
-    "geom:area_square_m":67841110.512263,
+    "geom:area_square_m":67841020.411876,
     "geom:bbox":"80.513498,7.18118,80.604529,7.263393",
     "geom:latitude":7.22284,
     "geom:longitude":80.561107,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KY.UN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899184,
-    "wof:geomhash":"f98c13563d1cdcd7f8198c5e741aa6a8",
+    "wof:geomhash":"cb2e8ba543d7600164db901df2582269",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066991,
-    "wof:lastmodified":1627522342,
+    "wof:lastmodified":1695886795,
     "wof:name":"Udunuwara",
     "wof:parent_id":85673719,
     "wof:placetype":"county",

--- a/data/109/206/699/7/1092066997.geojson
+++ b/data/109/206/699/7/1092066997.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04533,
-    "geom:area_square_m":555849469.325366,
+    "geom:area_square_m":555848816.540997,
     "geom:bbox":"81.463215,7.267071,81.745149,7.518269",
     "geom:latitude":7.397832,
     "geom:longitude":81.593618,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.AP.UH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899185,
-    "wof:geomhash":"e767dc95ae6233cafb35cd4b8e6582f4",
+    "wof:geomhash":"7f0bf8b744f412c62ae97c955dc64e9b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092066997,
-    "wof:lastmodified":1627522342,
+    "wof:lastmodified":1695886795,
     "wof:name":"Uhana",
     "wof:parent_id":85673733,
     "wof:placetype":"county",

--- a/data/109/206/702/5/1092067025.geojson
+++ b/data/109/206/702/5/1092067025.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006298,
-    "geom:area_square_m":77225988.846275,
+    "geom:area_square_m":77225977.370468,
     "geom:bbox":"80.566946,7.381617,80.711946,7.491402",
     "geom:latitude":7.428392,
     "geom:longitude":80.638399,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MT.UK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899187,
-    "wof:geomhash":"da9640edb005412f004f50149ab2f9e2",
+    "wof:geomhash":"4ab070f88b7ee5c3ac669963583570d5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092067025,
-    "wof:lastmodified":1627522342,
+    "wof:lastmodified":1695886795,
     "wof:name":"Ukuwela",
     "wof:parent_id":85673723,
     "wof:placetype":"county",

--- a/data/109/206/705/1/1092067051.geojson
+++ b/data/109/206/705/1/1092067051.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011372,
-    "geom:area_square_m":139582616.00721,
+    "geom:area_square_m":139582594.745777,
     "geom:bbox":"80.83067,6.907498,80.987248,7.064111",
     "geom:latitude":6.967405,
     "geom:longitude":80.91745,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BD.UP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899188,
-    "wof:geomhash":"df83108c2b525851bbc0a3f7e6b17573",
+    "wof:geomhash":"e5733a0b4a037352a4a37ae256b8f0a5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092067051,
-    "wof:lastmodified":1627522342,
+    "wof:lastmodified":1695886796,
     "wof:name":"Uva Paranagama",
     "wof:parent_id":85673801,
     "wof:placetype":"county",

--- a/data/109/206/707/1/1092067071.geojson
+++ b/data/109/206/707/1/1092067071.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014338,
-    "geom:area_square_m":174804911.584844,
+    "geom:area_square_m":174804961.703987,
     "geom:bbox":"80.238665,9.452203,80.62152,9.784393",
     "geom:latitude":9.6129,
     "geom:longitude":80.409049,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.JA.VE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899190,
-    "wof:geomhash":"7a04df5e4ec1c5ea3fdefb7e725bb4ff",
+    "wof:geomhash":"3647db00ad8f102aef31294e149b8b5e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092067071,
-    "wof:lastmodified":1627522342,
+    "wof:lastmodified":1695886796,
     "wof:name":"Vadamaradchy East",
     "wof:parent_id":85673769,
     "wof:placetype":"county",

--- a/data/109/206/709/5/1092067095.geojson
+++ b/data/109/206/709/5/1092067095.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002659,
-    "geom:area_square_m":32396361.501609,
+    "geom:area_square_m":32396373.838239,
     "geom:bbox":"80.123827,9.767726,80.268526,9.832084",
     "geom:latitude":9.804895,
     "geom:longitude":80.223978,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.JA.PP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899191,
-    "wof:geomhash":"309c67bb70401649ed4822e97d578ee0",
+    "wof:geomhash":"1688a8c5fd95646da248c442b2b63455",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092067095,
-    "wof:lastmodified":1627522342,
+    "wof:lastmodified":1695886796,
     "wof:name":"Vadamaradchy North (Point Pedro)",
     "wof:parent_id":85673769,
     "wof:placetype":"county",

--- a/data/109/206/712/5/1092067125.geojson
+++ b/data/109/206/712/5/1092067125.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007548,
-    "geom:area_square_m":91983198.429671,
+    "geom:area_square_m":91982883.42721,
     "geom:bbox":"80.130371,9.716509,80.246562,9.823876",
     "geom:latitude":9.775662,
     "geom:longitude":80.18423,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.JA.VD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899193,
-    "wof:geomhash":"f9b18b83a5cf77460316448c124a3a67",
+    "wof:geomhash":"25810b08e7224d3a7b98bb2efcf3f808",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092067125,
-    "wof:lastmodified":1627522343,
+    "wof:lastmodified":1695886796,
     "wof:name":"Vadamaradchy South-West (Karaveddy)",
     "wof:parent_id":85673769,
     "wof:placetype":"county",

--- a/data/109/206/713/1/1092067131.geojson
+++ b/data/109/206/713/1/1092067131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009222,
-    "geom:area_square_m":112386371.014272,
+    "geom:area_square_m":112386365.654434,
     "geom:bbox":"80.027782,9.666868,80.164124,9.815518",
     "geom:latitude":9.735362,
     "geom:longitude":80.094398,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.JA.VK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899194,
-    "wof:geomhash":"d100747365802beb1199ce641c4ab324",
+    "wof:geomhash":"61f8cb4a241b34382e4a0b0e8edfebb9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092067131,
-    "wof:lastmodified":1627522343,
+    "wof:lastmodified":1695886796,
     "wof:name":"Valikamam East (Kopay)",
     "wof:parent_id":85673769,
     "wof:placetype":"county",

--- a/data/109/206/714/3/1092067143.geojson
+++ b/data/109/206/714/3/1092067143.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004576,
-    "geom:area_square_m":55765302.639814,
+    "geom:area_square_m":55765266.681866,
     "geom:bbox":"79.987802,9.751787,80.094872,9.814584",
     "geom:latitude":9.787566,
     "geom:longitude":80.040868,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.JA.VN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899197,
-    "wof:geomhash":"1542e6bc6b29cb89f83e16a139205b0a",
+    "wof:geomhash":"f9c369dfbf3b1cd835faa6b06d94d704",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092067143,
-    "wof:lastmodified":1627522343,
+    "wof:lastmodified":1695886796,
     "wof:name":"Valikamam North",
     "wof:parent_id":85673769,
     "wof:placetype":"county",

--- a/data/109/206/718/5/1092067185.geojson
+++ b/data/109/206/718/5/1092067185.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002503,
-    "geom:area_square_m":30500734.59203,
+    "geom:area_square_m":30500663.965292,
     "geom:bbox":"79.990815,9.708936,80.083081,9.772245",
     "geom:latitude":9.746599,
     "geom:longitude":80.034678,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.JA.VS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899199,
-    "wof:geomhash":"8ad7fca3a98488cbef465c8976a85fbc",
+    "wof:geomhash":"be5355550b17d03975382866a7441892",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092067185,
-    "wof:lastmodified":1627522343,
+    "wof:lastmodified":1695886796,
     "wof:name":"Valikamam South (Uduvil)",
     "wof:parent_id":85673769,
     "wof:placetype":"county",

--- a/data/109/206/721/3/1092067213.geojson
+++ b/data/109/206/721/3/1092067213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004007,
-    "geom:area_square_m":48831590.647032,
+    "geom:area_square_m":48831878.138913,
     "geom:bbox":"79.943691,9.682531,80.012787,9.807898",
     "geom:latitude":9.747204,
     "geom:longitude":79.982182,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.JA.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899200,
-    "wof:geomhash":"d23241195d80b74799f8cff2c706ad04",
+    "wof:geomhash":"636a5b2eae0d741e3b72711221f2c16b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092067213,
-    "wof:lastmodified":1627522343,
+    "wof:lastmodified":1695886796,
     "wof:name":"Valikamam South-West (Sandilipay)",
     "wof:parent_id":85673769,
     "wof:placetype":"county",

--- a/data/109/206/725/5/1092067255.geojson
+++ b/data/109/206/725/5/1092067255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003786,
-    "geom:area_square_m":46134192.098051,
+    "geom:area_square_m":46133993.57967,
     "geom:bbox":"79.906219,9.687889,79.98328,9.781616",
     "geom:latitude":9.739443,
     "geom:longitude":79.947223,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.JA.VW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899201,
-    "wof:geomhash":"551c2353151928431d2e729aa0e28aea",
+    "wof:geomhash":"d2e260a505901fbab22bac0ab2ed1ed2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092067255,
-    "wof:lastmodified":1627522343,
+    "wof:lastmodified":1695886796,
     "wof:name":"Valikamam West (Chankanai)",
     "wof:parent_id":85673769,
     "wof:placetype":"county",

--- a/data/109/206/729/7/1092067297.geojson
+++ b/data/109/206/729/7/1092067297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053798,
-    "geom:area_square_m":657018677.035102,
+    "geom:area_square_m":657018820.459559,
     "geom:bbox":"80.375819,8.868015,80.731663,9.128546",
     "geom:latitude":9.007963,
     "geom:longitude":80.568862,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.VA.VN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899203,
-    "wof:geomhash":"410d3bdc9a70650d878f03372f2ba51d",
+    "wof:geomhash":"a0de30d0c0f03e14fdbf13abca583b2d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092067297,
-    "wof:lastmodified":1627522343,
+    "wof:lastmodified":1695886796,
     "wof:name":"Vavuniya North",
     "wof:parent_id":85673757,
     "wof:placetype":"county",

--- a/data/109/206/734/1/1092067341.geojson
+++ b/data/109/206/734/1/1092067341.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017683,
-    "geom:area_square_m":216115303.56302,
+    "geom:area_square_m":216114960.993543,
     "geom:bbox":"80.346369,8.570681,80.652654,8.83717",
     "geom:latitude":8.736996,
     "geom:longitude":80.517235,
@@ -146,9 +146,10 @@
         "hasc:id":"LK.VA.VS",
         "wd:id":"Q527980"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899204,
-    "wof:geomhash":"8f3a557928615e0ffe94125c3fd09dc6",
+    "wof:geomhash":"70e3923d0573b5811e87740393fc66a0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":1092067341,
-    "wof:lastmodified":1690938551,
+    "wof:lastmodified":1695886708,
     "wof:name":"Vavuniya South",
     "wof:parent_id":85673757,
     "wof:placetype":"county",

--- a/data/109/206/738/3/1092067383.geojson
+++ b/data/109/206/738/3/1092067383.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050698,
-    "geom:area_square_m":619457333.104082,
+    "geom:area_square_m":619457354.117159,
     "geom:bbox":"80.275697,8.665499,80.61766,8.977662",
     "geom:latitude":8.833942,
     "geom:longitude":80.456652,
@@ -145,9 +145,10 @@
         "hasc:id":"LK.VA.VA",
         "wd:id":"Q527980"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899206,
-    "wof:geomhash":"df35e182e2df109fb30d4304d14d7e8e",
+    "wof:geomhash":"32b71a69577dd3c09bacfef12ecca7aa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1092067383,
-    "wof:lastmodified":1690938549,
+    "wof:lastmodified":1695886707,
     "wof:name":"Vavuniya",
     "wof:parent_id":85673757,
     "wof:placetype":"county",

--- a/data/109/206/743/1/1092067431.geojson
+++ b/data/109/206/743/1/1092067431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033894,
-    "geom:area_square_m":414293330.100334,
+    "geom:area_square_m":414293663.13664,
     "geom:bbox":"80.171013,8.547635,80.450707,8.827603",
     "geom:latitude":8.693086,
     "geom:longitude":80.29677,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.VA.VE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899208,
-    "wof:geomhash":"35370c4f42e151c1d946f3638a70033e",
+    "wof:geomhash":"315c1759bec8406ae14d934e77fce296",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092067431,
-    "wof:lastmodified":1627522343,
+    "wof:lastmodified":1695886796,
     "wof:name":"Vengalacheddikulam",
     "wof:parent_id":85673757,
     "wof:placetype":"county",

--- a/data/109/206/746/7/1092067467.geojson
+++ b/data/109/206/746/7/1092067467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008331,
-    "geom:area_square_m":101938855.784297,
+    "geom:area_square_m":101938757.241363,
     "geom:bbox":"81.268738,8.25215,81.404556,8.410573",
     "geom:latitude":8.301112,
     "geom:longitude":81.346394,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.TC.VE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899209,
-    "wof:geomhash":"8a01583c59aae6618c0c10fd54fe7793",
+    "wof:geomhash":"f07e4e61dbbc45d7866522405b68bf7c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092067467,
-    "wof:lastmodified":1627522343,
+    "wof:lastmodified":1695886796,
     "wof:name":"Verugal Eachchilampattu",
     "wof:parent_id":85673747,
     "wof:placetype":"county",

--- a/data/109/206/749/3/1092067493.geojson
+++ b/data/109/206/749/3/1092067493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017407,
-    "geom:area_square_m":213894726.300914,
+    "geom:area_square_m":213894633.979597,
     "geom:bbox":"80.061818,6.327663,80.301206,6.472011",
     "geom:latitude":6.40756,
     "geom:longitude":80.187168,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KT.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899210,
-    "wof:geomhash":"1761495d7cca84c90f4a4420c4c110d5",
+    "wof:geomhash":"324305b9cd448a0af2cd579d16fd14a3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092067493,
-    "wof:lastmodified":1627522343,
+    "wof:lastmodified":1695886796,
     "wof:name":"Walallavita",
     "wof:parent_id":85673819,
     "wof:placetype":"county",

--- a/data/109/206/753/5/1092067535.geojson
+++ b/data/109/206/753/5/1092067535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026001,
-    "geom:area_square_m":319051012.349433,
+    "geom:area_square_m":319051501.24609,
     "geom:bbox":"80.796688,6.971583,80.965365,7.202805",
     "geom:latitude":7.092658,
     "geom:longitude":80.886837,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.NW.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899212,
-    "wof:geomhash":"e8dd42db1f090c64b30d74670a135430",
+    "wof:geomhash":"f3ab5db992586b9fb761530aa57ff0fb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092067535,
-    "wof:lastmodified":1627522343,
+    "wof:lastmodified":1695886796,
     "wof:name":"Walapane",
     "wof:parent_id":85673731,
     "wof:placetype":"county",

--- a/data/109/206/757/3/1092067573.geojson
+++ b/data/109/206/757/3/1092067573.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008745,
-    "geom:area_square_m":107503179.987148,
+    "geom:area_square_m":107503304.102262,
     "geom:bbox":"80.608318,6.14692,80.751412,6.252773",
     "geom:latitude":6.200884,
     "geom:longitude":80.680905,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.HB.WM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899213,
-    "wof:geomhash":"474132ccf02956583ff209a18bba89b5",
+    "wof:geomhash":"0c4b787f092eb408035af4054e053b60",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092067573,
-    "wof:lastmodified":1627522343,
+    "wof:lastmodified":1695886796,
     "wof:name":"Walasmulla",
     "wof:parent_id":85673791,
     "wof:placetype":"county",

--- a/data/109/206/760/9/1092067609.geojson
+++ b/data/109/206/760/9/1092067609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060398,
-    "geom:area_square_m":738928411.248962,
+    "geom:area_square_m":738928392.042434,
     "geom:bbox":"79.787918,8.08678,80.043116,8.572059",
     "geom:latitude":8.341712,
     "geom:longitude":79.910513,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.PX.VA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899215,
-    "wof:geomhash":"13787720498d48f49702e4d262401bfd",
+    "wof:geomhash":"016df8a1663585099ed3567bbe934e4d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092067609,
-    "wof:lastmodified":1627522343,
+    "wof:lastmodified":1695886796,
     "wof:name":"Wanathavilluwa",
     "wof:parent_id":85673779,
     "wof:placetype":"county",

--- a/data/109/206/764/7/1092067647.geojson
+++ b/data/109/206/764/7/1092067647.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016116,
-    "geom:area_square_m":197705672.492411,
+    "geom:area_square_m":197705736.254736,
     "geom:bbox":"80.150923,7.094939,80.290833,7.317696",
     "geom:latitude":7.203928,
     "geom:longitude":80.23188,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KE.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899216,
-    "wof:geomhash":"34e9691e8bd562097f34961b5d6e5e07",
+    "wof:geomhash":"0ab79cbb3578a4ed1892c4f50b0bd067",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092067647,
-    "wof:lastmodified":1627522343,
+    "wof:lastmodified":1695886796,
     "wof:name":"Warakapola",
     "wof:parent_id":85673807,
     "wof:placetype":"county",

--- a/data/109/206/768/5/1092067685.geojson
+++ b/data/109/206/768/5/1092067685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016592,
-    "geom:area_square_m":203327314.393532,
+    "geom:area_square_m":203327053.808176,
     "geom:bbox":"80.156015,7.587438,80.340549,7.737614",
     "geom:latitude":7.66329,
     "geom:longitude":80.239459,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899217,
-    "wof:geomhash":"e82eadbf5c0675a026b7006eff10e051",
+    "wof:geomhash":"2b35d3a824004af40152eb2144efa429",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092067685,
-    "wof:lastmodified":1627522343,
+    "wof:lastmodified":1695886796,
     "wof:name":"Wariyapola",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/206/772/5/1092067725.geojson
+++ b/data/109/206/772/5/1092067725.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005007,
-    "geom:area_square_m":61442699.646574,
+    "geom:area_square_m":61442474.092639,
     "geom:bbox":"79.841328,6.971214,79.939432,7.1169",
     "geom:latitude":7.036039,
     "geom:longitude":79.881962,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GQ.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899219,
-    "wof:geomhash":"48a1ca401aba97bdf7823268f1929923",
+    "wof:geomhash":"242342503e3e6ed7c0552e73af08fab8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1092067725,
-    "wof:lastmodified":1627522343,
+    "wof:lastmodified":1695886796,
     "wof:name":"Wattala",
     "wof:parent_id":85673815,
     "wof:placetype":"county",

--- a/data/109/206/773/9/1092067739.geojson
+++ b/data/109/206/773/9/1092067739.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009478,
-    "geom:area_square_m":116523041.911808,
+    "geom:area_square_m":116523041.911851,
     "geom:bbox":"80.7170625736,6.09568078701,80.8422596212,6.24662727251",
     "geom:latitude":6.171908,
     "geom:longitude":80.772033,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.HB.WE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899220,
-    "wof:geomhash":"277c7fe9457ee0f11f678cabbf883835",
+    "wof:geomhash":"9603b1d1d31f28c79230d499a91dfdf9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092067739,
-    "wof:lastmodified":1566595312,
+    "wof:lastmodified":1695886708,
     "wof:name":"Weeraketiya",
     "wof:parent_id":85673791,
     "wof:placetype":"county",

--- a/data/109/206/778/3/1092067783.geojson
+++ b/data/109/206/778/3/1092067783.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007752,
-    "geom:area_square_m":95040170.646226,
+    "geom:area_square_m":95040287.045785,
     "geom:bbox":"80.215263,7.408561,80.331183,7.526222",
     "geom:latitude":7.465801,
     "geom:longitude":80.272502,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KG.WE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899222,
-    "wof:geomhash":"13593f0ce5194b437cbdd8a90921f27b",
+    "wof:geomhash":"cf952690a6d8052d311dd1d02c3a419e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092067783,
-    "wof:lastmodified":1627522344,
+    "wof:lastmodified":1695886796,
     "wof:name":"Weerambugedara",
     "wof:parent_id":85673777,
     "wof:placetype":"county",

--- a/data/109/206/782/7/1092067827.geojson
+++ b/data/109/206/782/7/1092067827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00405,
-    "geom:area_square_m":49806484.657864,
+    "geom:area_square_m":49806484.657857,
     "geom:bbox":"80.380077466,5.932055473,80.5066570878,6.00138486708",
     "geom:latitude":5.965803,
     "geom:longitude":80.444028,
@@ -96,9 +96,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MH.WG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899223,
-    "wof:geomhash":"1e0dc44615d85a842596f2b65dd6abe0",
+    "wof:geomhash":"53a02296e57da1cb601e15f60fafc3c4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1092067827,
-    "wof:lastmodified":1566595297,
+    "wof:lastmodified":1695886708,
     "wof:name":"Weligama",
     "wof:parent_id":85673795,
     "wof:placetype":"county",

--- a/data/109/206/785/1/1092067851.geojson
+++ b/data/109/206/785/1/1092067851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016426,
-    "geom:area_square_m":201785879.217946,
+    "geom:area_square_m":201785893.105715,
     "geom:bbox":"80.645316,6.474087,80.834506,6.611001",
     "geom:latitude":6.541661,
     "geom:longitude":80.744442,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.RN.WE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899225,
-    "wof:geomhash":"7fd4cccc4e4fad2fd02fca8d6cc95f2b",
+    "wof:geomhash":"bd3c5c84ff51c7a17d2fefd275551a96",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092067851,
-    "wof:lastmodified":1627522344,
+    "wof:lastmodified":1695886796,
     "wof:name":"Weligepola",
     "wof:parent_id":85673785,
     "wof:placetype":"county",

--- a/data/109/206/789/1/1092067891.geojson
+++ b/data/109/206/789/1/1092067891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047315,
-    "geom:area_square_m":579310142.093691,
+    "geom:area_square_m":579309890.872605,
     "geom:bbox":"81.119373,7.863821,81.341634,8.260279",
     "geom:latitude":8.040919,
     "geom:longitude":81.2344,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.PR.WE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899226,
-    "wof:geomhash":"01870c942576f75ff6a51804725a855d",
+    "wof:geomhash":"5c1626af3e7c28e1e5810da832ca82d5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092067891,
-    "wof:lastmodified":1627522344,
+    "wof:lastmodified":1695886796,
     "wof:name":"Welikanda",
     "wof:parent_id":85673743,
     "wof:placetype":"county",

--- a/data/109/206/793/3/1092067933.geojson
+++ b/data/109/206/793/3/1092067933.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015773,
-    "geom:area_square_m":193637954.609363,
+    "geom:area_square_m":193638092.057187,
     "geom:bbox":"80.778202,6.776627,80.959311,6.929276",
     "geom:latitude":6.860151,
     "geom:longitude":80.881253,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.BD.WE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899228,
-    "wof:geomhash":"a1ce0256c8dde9d5c6b6ce0b569329f0",
+    "wof:geomhash":"0345cc486a05696bbd18cc5392fc4bed",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092067933,
-    "wof:lastmodified":1627522344,
+    "wof:lastmodified":1695886796,
     "wof:name":"Welimada",
     "wof:parent_id":85673801,
     "wof:placetype":"county",

--- a/data/109/206/797/5/1092067975.geojson
+++ b/data/109/206/797/5/1092067975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015135,
-    "geom:area_square_m":184856768.073671,
+    "geom:area_square_m":184856943.203984,
     "geom:bbox":"80.691809,8.894181,80.878799,9.053815",
     "geom:latitude":8.977263,
     "geom:longitude":80.772189,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MP.WE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899229,
-    "wof:geomhash":"836a2bbf37073555b0c3850fcb9dfdca",
+    "wof:geomhash":"b4be2e64cd51c867617a1d762c0a1d55",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092067975,
-    "wof:lastmodified":1627522344,
+    "wof:lastmodified":1695886797,
     "wof:name":"Welioya",
     "wof:parent_id":85673765,
     "wof:placetype":"county",

--- a/data/109/206/800/3/1092068003.geojson
+++ b/data/109/206/800/3/1092068003.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005491,
-    "geom:area_square_m":67520084.156693,
+    "geom:area_square_m":67519858.025087,
     "geom:bbox":"80.386524,5.964569,80.490784,6.068399",
     "geom:latitude":6.016712,
     "geom:longitude":80.438874,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MH.WP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899230,
-    "wof:geomhash":"efa97b4eddeadd1d09b7e5f04c84bffc",
+    "wof:geomhash":"6d969a1083cf6f5b5eff390f00f252e8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092068003,
-    "wof:lastmodified":1627522344,
+    "wof:lastmodified":1695886797,
     "wof:name":"Welipitiya",
     "wof:parent_id":85673795,
     "wof:placetype":"county",

--- a/data/109/206/804/5/1092068045.geojson
+++ b/data/109/206/804/5/1092068045.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00443,
-    "geom:area_square_m":54460837.727551,
+    "geom:area_square_m":54460545.140626,
     "geom:bbox":"80.136416,6.169588,80.243272,6.258647",
     "geom:latitude":6.206203,
     "geom:longitude":80.179845,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GL.WD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899232,
-    "wof:geomhash":"5d22832b6fec4bae752aa24a6c1575b3",
+    "wof:geomhash":"eacbc106c65773f7239c5411499d4090",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092068045,
-    "wof:lastmodified":1627522344,
+    "wof:lastmodified":1695886797,
     "wof:name":"Welivitiya-Divithura",
     "wof:parent_id":85673789,
     "wof:placetype":"county",

--- a/data/109/206/808/7/1092068087.geojson
+++ b/data/109/206/808/7/1092068087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048057,
-    "geom:area_square_m":590279641.630275,
+    "geom:area_square_m":590279366.395021,
     "geom:bbox":"81.020152,6.44765,81.239647,6.833211",
     "geom:latitude":6.612531,
     "geom:longitude":81.1231,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MJ.WE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899233,
-    "wof:geomhash":"99707cdaf99e7f5d12be825a0ba927b0",
+    "wof:geomhash":"66c8880cc45bca3d0e382999f8103dd0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092068087,
-    "wof:lastmodified":1627522344,
+    "wof:lastmodified":1695886797,
     "wof:name":"Wellawaya",
     "wof:parent_id":85673803,
     "wof:placetype":"county",

--- a/data/109/206/812/1/1092068121.geojson
+++ b/data/109/206/812/1/1092068121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003265,
-    "geom:area_square_m":40042421.671641,
+    "geom:area_square_m":40042428.422158,
     "geom:bbox":"79.827805,7.270788,79.882847,7.371889",
     "geom:latitude":7.324929,
     "geom:longitude":79.854483,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"LK.PX.WE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899235,
-    "wof:geomhash":"cf71c31e975910e7fb2fadc6c286b4e3",
+    "wof:geomhash":"facaa202089c738f4f2f81870498cc18",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1092068121,
-    "wof:lastmodified":1627522344,
+    "wof:lastmodified":1695886797,
     "wof:name":"Wennappuwa",
     "wof:parent_id":85673779,
     "wof:placetype":"county",

--- a/data/109/206/816/1/1092068161.geojson
+++ b/data/109/206/816/1/1092068161.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023495,
-    "geom:area_square_m":287965459.383519,
+    "geom:area_square_m":287965740.712469,
     "geom:bbox":"80.869908,7.461259,80.998496,7.71922",
     "geom:latitude":7.604357,
     "geom:longitude":80.929003,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MT.WI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899236,
-    "wof:geomhash":"2eff848b8ade605558344bc088bef849",
+    "wof:geomhash":"8f0b2161fde42e4c9bfe7e12101cca8b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092068161,
-    "wof:lastmodified":1627522344,
+    "wof:lastmodified":1695886797,
     "wof:name":"Wilgamuwa",
     "wof:parent_id":85673723,
     "wof:placetype":"county",

--- a/data/109/206/820/3/1092068203.geojson
+++ b/data/109/206/820/3/1092068203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008939,
-    "geom:area_square_m":109911069.905087,
+    "geom:area_square_m":109910823.405119,
     "geom:bbox":"80.281406,6.053446,80.43722,6.162181",
     "geom:latitude":6.106801,
     "geom:longitude":80.359426,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"LK.GL.YA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899238,
-    "wof:geomhash":"62624d8d1c3ec2d5ffeac62713e341f1",
+    "wof:geomhash":"756944fa39407b78e19f3638ee2abb62",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092068203,
-    "wof:lastmodified":1627522344,
+    "wof:lastmodified":1695886797,
     "wof:name":"Yakkalamulla",
     "wof:parent_id":85673789,
     "wof:placetype":"county",

--- a/data/109/206/824/3/1092068243.geojson
+++ b/data/109/206/824/3/1092068243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005316,
-    "geom:area_square_m":65158346.088866,
+    "geom:area_square_m":65158385.053727,
     "geom:bbox":"80.551442,7.485214,80.630104,7.604372",
     "geom:latitude":7.549375,
     "geom:longitude":80.588453,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"LK.MT.YA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899239,
-    "wof:geomhash":"6731e90a3d2c39e1a593ddcdf18f5c5a",
+    "wof:geomhash":"e9cf3cbe9aa3afc099922275e192a78d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1092068243,
-    "wof:lastmodified":1627522344,
+    "wof:lastmodified":1695886797,
     "wof:name":"Yatawatta",
     "wof:parent_id":85673723,
     "wof:placetype":"county",

--- a/data/109/206/826/7/1092068267.geojson
+++ b/data/109/206/826/7/1092068267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005594,
-    "geom:area_square_m":68609513.845015,
+    "geom:area_square_m":68609384.215136,
     "geom:bbox":"80.472815,7.246205,80.601866,7.318729",
     "geom:latitude":7.282242,
     "geom:longitude":80.537571,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KY.YA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899240,
-    "wof:geomhash":"444b64a9a95225d32651c0b7f46e4a83",
+    "wof:geomhash":"1fd7b5ab67bfd8d7ef697c5e4a329649",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092068267,
-    "wof:lastmodified":1627522344,
+    "wof:lastmodified":1695886797,
     "wof:name":"Yatinuwara",
     "wof:parent_id":85673719,
     "wof:placetype":"county",

--- a/data/109/206/830/5/1092068305.geojson
+++ b/data/109/206/830/5/1092068305.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014231,
-    "geom:area_square_m":174653148.469208,
+    "geom:area_square_m":174652814.167556,
     "geom:bbox":"80.262784,6.955314,80.467046,7.112039",
     "geom:latitude":7.027195,
     "geom:longitude":80.370879,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"LK.KE.YA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1473899242,
-    "wof:geomhash":"14c81f4b593675f3495814d9625e810f",
+    "wof:geomhash":"dfca1013c7df2af294907564f4462a77",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1092068305,
-    "wof:lastmodified":1627522344,
+    "wof:lastmodified":1695886797,
     "wof:name":"Yatiyanthota",
     "wof:parent_id":85673807,
     "wof:placetype":"county",

--- a/data/856/323/13/85632313.geojson
+++ b/data/856/323/13/85632313.geojson
@@ -1182,6 +1182,7 @@
         "hasc:id":"LK",
         "icao:code":"4R",
         "ioc:id":"SRI",
+        "iso:code":"LK",
         "itu:id":"CLN",
         "m49:code":"144",
         "marc:id":"ce",
@@ -1195,6 +1196,7 @@
         "wk:page":"Sri Lanka",
         "wmo:id":"SB"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:country_alpha3":"LKA",
     "wof:geom_alt":[
@@ -1218,7 +1220,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1694639527,
+    "wof:lastmodified":1695881183,
     "wof:name":"Sri Lanka",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/737/19/85673719.geojson
+++ b/data/856/737/19/85673719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.157892,
-    "geom:area_square_m":1936656928.928636,
+    "geom:area_square_m":1936656264.17239,
     "geom:bbox":"80.420983,6.939025,81.017836,7.491384",
     "geom:latitude":7.272767,
     "geom:longitude":80.709578,
@@ -228,17 +228,19 @@
         "gn:id":1241621,
         "gp:id":23706513,
         "hasc:id":"LK.KY",
+        "iso:code":"LK-21",
         "iso:id":"LK-21",
         "qs_pg:id":1192924,
         "unlc:id":"LK-21",
         "wd:id":"Q723002",
         "wk:page":"Kandy District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ebae9fa2d1631ed5789ef425ae901ee4",
+    "wof:geomhash":"5b8d731c29d163a6436dba85ee763885",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -255,7 +257,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938538,
+    "wof:lastmodified":1695884871,
     "wof:name":"Mahanuvara",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/23/85673723.geojson
+++ b/data/856/737/23/85673723.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.168565,
-    "geom:area_square_m":2065690735.958346,
+    "geom:area_square_m":2065690643.316071,
     "geom:bbox":"80.496324,7.381617,80.998496,8.011592",
     "geom:latitude":7.667999,
     "geom:longitude":80.730874,
@@ -264,17 +264,19 @@
         "gn:id":1235854,
         "gp:id":23706512,
         "hasc:id":"LK.MT",
+        "iso:code":"LK-22",
         "iso:id":"LK-22",
         "qs_pg:id":1192923,
         "unlc:id":"LK-22",
         "wd:id":"Q787421",
         "wk:page":"Matale District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"45012f112d41239aa6e302342006a104",
+    "wof:geomhash":"7a07a2ed6a427a7b24c71b21f99e841f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -291,7 +293,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938540,
+    "wof:lastmodified":1695884362,
     "wof:name":"M\u0101tale",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/31/85673731.geojson
+++ b/data/856/737/31/85673731.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.142339,
-    "geom:area_square_m":1747028391.459455,
+    "geom:area_square_m":1747029012.573438,
     "geom:bbox":"80.42967,6.74985,80.965365,7.268516",
     "geom:latitude":6.97398,
     "geom:longitude":80.711584,
@@ -264,17 +264,19 @@
         "gn:id":1232781,
         "gp:id":23706511,
         "hasc:id":"LK.NW",
+        "iso:code":"LK-23",
         "iso:id":"LK-23",
         "qs_pg:id":1192922,
         "unlc:id":"LK-23",
         "wd:id":"Q1583950",
         "wk:page":"Nuwara Eliya District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a02f023eb7d05c87a7fbf77c4f1e1348",
+    "wof:geomhash":"f33f577d89a1db43bc13d3196ad16029",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -291,7 +293,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938538,
+    "wof:lastmodified":1695884361,
     "wof:name":"Nuvara \u0114liya",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/33/85673733.geojson
+++ b/data/856/737/33/85673733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.368117,
-    "geom:area_square_m":4515523403.06983,
+    "geom:area_square_m":4515523553.427711,
     "geom:bbox":"80.979898,6.508267,81.880386,7.738533",
     "geom:latitude":7.236253,
     "geom:longitude":81.550369,
@@ -265,16 +265,18 @@
         "gn:id":1251460,
         "gp:id":23706509,
         "hasc:id":"LK.AP",
+        "iso:code":"LK-52",
         "iso:id":"LK-52",
         "qs_pg:id":888196,
         "unlc:id":"LK-52",
         "wd:id":"Q474395"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b6c835c1af6f324c0045c6ad44aaef03",
+    "wof:geomhash":"d1ef4e4076640b2d581c0039aff92e13",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -291,7 +293,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938537,
+    "wof:lastmodified":1695884361,
     "wof:name":"Amp\u0101ra",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/37/85673737.geojson
+++ b/data/856/737/37/85673737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.213478,
-    "geom:area_square_m":2615314264.126301,
+    "geom:area_square_m":2615314030.607331,
     "geom:bbox":"81.225877,7.406238,81.819588,8.267027",
     "geom:latitude":7.791246,
     "geom:longitude":81.492913,
@@ -225,16 +225,18 @@
         "gn:id":1250159,
         "gp:id":23706508,
         "hasc:id":"LK.BC",
+        "iso:code":"LK-51",
         "iso:id":"LK-51",
         "qs_pg:id":888195,
         "unlc:id":"LK-51",
         "wd:id":"Q810960"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2770c1a4ee40661468a04197ab963c2a",
+    "wof:geomhash":"64ffef3bd3011255f720bd8838eff962",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -251,7 +253,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938539,
+    "wof:lastmodified":1695884362,
     "wof:name":"Ma\u1e0dakalapuva",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/43/85673743.geojson
+++ b/data/856/737/43/85673743.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.282699,
-    "geom:area_square_m":3461645446.039036,
+    "geom:area_square_m":3461645501.053278,
     "geom:bbox":"80.749645,7.646209,81.341634,8.348873",
     "geom:latitude":7.993568,
     "geom:longitude":81.025978,
@@ -264,17 +264,19 @@
         "gn:id":1229899,
         "gp:id":23706504,
         "hasc:id":"LK.PR",
+        "iso:code":"LK-72",
         "iso:id":"LK-72",
         "qs_pg:id":1086139,
         "unlc:id":"LK-72",
         "wd:id":"Q931057",
         "wk:page":"Polonnaruwa District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"376112a04a15677dabc991fe9212a420",
+    "wof:geomhash":"91d484326d0fc4746878d095cbcc4684",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -291,7 +293,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938538,
+    "wof:lastmodified":1695884361,
     "wof:name":"P\u014f\u1e37\u014fnnaruva",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/47/85673747.geojson
+++ b/data/856/737/47/85673747.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.221059,
-    "geom:area_square_m":2703015185.246001,
+    "geom:area_square_m":2703014794.348717,
     "geom:bbox":"80.756156,8.149927,81.404556,8.989754",
     "geom:latitude":8.554005,
     "geom:longitude":81.09165,
@@ -216,16 +216,18 @@
         "gn:id":1226258,
         "gp:id":23706507,
         "hasc:id":"LK.TC",
+        "iso:code":"LK-53",
         "iso:id":"LK-53",
         "qs_pg:id":212352,
         "unlc:id":"LK-53",
         "wd:id":"Q1493318"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fe93bcf3d20884aaae759e324c228435",
+    "wof:geomhash":"524b8208f8dd0ee08bd694305f99423c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -242,7 +244,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938541,
+    "wof:lastmodified":1695884362,
     "wof:name":"Triku\u1e47\u0101malaya",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/51/85673751.geojson
+++ b/data/856/737/51/85673751.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.592285,
-    "geom:area_square_m":7245243014.690964,
+    "geom:area_square_m":7245243486.229672,
     "geom:bbox":"79.951692,7.817885,80.993661,8.921778",
     "geom:latitude":8.39227,
     "geom:longitude":80.512727,
@@ -216,17 +216,19 @@
         "gn:id":1251080,
         "gp:id":23706503,
         "hasc:id":"LK.AD",
+        "iso:code":"LK-71",
         "iso:id":"LK-71",
         "qs_pg:id":1086138,
         "unlc:id":"LK-71",
         "wd:id":"Q612614",
         "wk:page":"Anuradhapura District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9e5a24378c1dee9543d20600f8fb4ee2",
+    "wof:geomhash":"b999808b7f213daf5645be37eb36aa67",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -243,7 +245,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938537,
+    "wof:lastmodified":1695884361,
     "wof:name":"Anur\u0101dhapura",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/57/85673757.geojson
+++ b/data/856/737/57/85673757.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.156073,
-    "geom:area_square_m":1906884643.802758,
+    "geom:area_square_m":1906884798.70709,
     "geom:bbox":"80.171013,8.547635,80.731663,9.128546",
     "geom:latitude":8.852353,
     "geom:longitude":80.467473,
@@ -239,16 +239,18 @@
         "gn:id":1225017,
         "gp:id":23706510,
         "hasc:id":"LK.VA",
+        "iso:code":"LK-44",
         "iso:id":"LK-44",
         "qs_pg:id":1236500,
         "unlc:id":"LK-44",
         "wd:id":"Q527980"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"28bb7258955e4b33b4d94f81612d58e1",
+    "wof:geomhash":"aaa20f3fe7a5e1c0b917aafa2df17384",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -265,7 +267,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938536,
+    "wof:lastmodified":1695884361,
     "wof:name":"Vavuniy\u0101va",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/61/85673761.geojson
+++ b/data/856/737/61/85673761.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.162138,
-    "geom:area_square_m":1980843942.464025,
+    "geom:area_square_m":1980843897.17685,
     "geom:bbox":"79.683746,8.522652,80.401262,9.233184",
     "geom:latitude":8.876512,
     "geom:longitude":80.091896,
@@ -262,16 +262,18 @@
         "gn:id":1236148,
         "gp:id":23706506,
         "hasc:id":"LK.MB",
+        "iso:code":"LK-43",
         "iso:id":"LK-43",
         "qs_pg:id":953632,
         "unlc:id":"LK-43",
         "wd:id":"Q178003"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"16dd05d5d49dfa5f31d8935597fd3999",
+    "wof:geomhash":"4b1f1d208758e6aee13de718058fe1e6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -288,7 +290,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938536,
+    "wof:lastmodified":1695884361,
     "wof:name":"Mann\u0101rama",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/65/85673765.geojson
+++ b/data/856/737/65/85673765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.221127,
-    "geom:area_square_m":2699363086.421017,
+    "geom:area_square_m":2699363676.307877,
     "geom:bbox":"80.175165,8.894181,80.963722,9.458844",
     "geom:latitude":9.165492,
     "geom:longitude":80.551345,
@@ -290,15 +290,17 @@
         "gn:id":1234392,
         "gp:id":23706505,
         "hasc:id":"LK.MP",
+        "iso:code":"LK-45",
         "iso:id":"LK-45",
         "qs_pg:id":1236499,
         "wd:id":"Q1587508"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fa785631242eebdfd0920cd25729aa73",
+    "wof:geomhash":"321ac74135df5c96121c21d703829aa9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -315,7 +317,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938539,
+    "wof:lastmodified":1695884871,
     "wof:name":"Mulativ",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/69/85673769.geojson
+++ b/data/856/737/69/85673769.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086846,
-    "geom:area_square_m":1058558525.017946,
+    "geom:area_square_m":1058558115.13041,
     "geom:bbox":"79.652031,9.452203,80.62152,9.832084",
     "geom:latitude":9.687581,
     "geom:longitude":80.114216,
@@ -213,16 +213,18 @@
         "gn:id":1242831,
         "gp:id":23706489,
         "hasc:id":"LK.JA",
+        "iso:code":"LK-41",
         "iso:id":"LK-41",
         "qs_pg:id":1085900,
         "unlc:id":"LK-41",
         "wd:id":"Q1520182"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"022bc6e75f19d19f6b95910735d33a39",
+    "wof:geomhash":"c84c0ee5fe7d497a6b4aa86c229abe85",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -239,7 +241,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938536,
+    "wof:lastmodified":1695884361,
     "wof:name":"Y\u0101panaya",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/73/85673773.geojson
+++ b/data/856/737/73/85673773.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.108791,
-    "geom:area_square_m":1327070741.230597,
+    "geom:area_square_m":1327070267.466948,
     "geom:bbox":"79.971222,9.207714,80.61587,9.680803",
     "geom:latitude":9.421652,
     "geom:longitude":80.312391,
@@ -259,16 +259,18 @@
         "gn:id":1240371,
         "gp:id":23706490,
         "hasc:id":"LK.KL",
+        "iso:code":"LK-42",
         "iso:id":"LK-42",
         "qs_pg:id":891828,
         "unlc:id":"LK-42",
         "wd:id":"Q1584007"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8e4389b139ba65308342529ccda21149",
+    "wof:geomhash":"0d1aace0a79867414bf2a9ee2cc79b56",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -285,7 +287,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938538,
+    "wof:lastmodified":1695884361,
     "wof:name":"Kilin\u014fchchi",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/77/85673777.geojson
+++ b/data/856/737/77/85673777.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.402193,
-    "geom:area_square_m":4928732264.173626,
+    "geom:area_square_m":4928732193.883037,
     "geom:bbox":"79.899324,7.256488,80.577423,8.192452",
     "geom:latitude":7.664687,
     "geom:longitude":80.23677,
@@ -261,17 +261,19 @@
         "gn:id":1237978,
         "gp:id":23706501,
         "hasc:id":"LK.KG",
+        "iso:code":"LK-61",
         "iso:id":"LK-61",
         "qs_pg:id":219952,
         "unlc:id":"LK-61",
         "wd:id":"Q745073",
         "wk:page":"Kurunegala District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eea228c13cc8ebbd339db2122ac81d36",
+    "wof:geomhash":"bd952ec81c5c9342d0fc7daace802d27",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -288,7 +290,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938540,
+    "wof:lastmodified":1695884362,
     "wof:name":"Kuru\u1e47\u00e6gala",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/79/85673779.geojson
+++ b/data/856/737/79/85673779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.258961,
-    "geom:area_square_m":3171089004.641731,
+    "geom:area_square_m":3171088550.869703,
     "geom:bbox":"79.695389,7.270788,80.15397,8.572059",
     "geom:latitude":7.975155,
     "geom:longitude":79.913508,
@@ -267,17 +267,19 @@
         "gn:id":1229292,
         "gp:id":23706502,
         "hasc:id":"LK.PX",
+        "iso:code":"LK-62",
         "iso:id":"LK-62",
         "qs_pg:id":888262,
         "unlc:id":"LK-62",
         "wd:id":"Q1665318",
         "wk:page":"Puttalam District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0c47dad93c8ceb74b434b6d466742db9",
+    "wof:geomhash":"fea92c25e7e92c2d1da322be2c1fc880",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -294,7 +296,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938540,
+    "wof:lastmodified":1695884871,
     "wof:name":"Puttalama",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/85/85673785.geojson
+++ b/data/856/737/85/85673785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.268625,
-    "geom:area_square_m":3299660592.426792,
+    "geom:area_square_m":3299660544.675487,
     "geom:bbox":"80.175589,6.228478,80.951912,6.929675",
     "geom:latitude":6.586947,
     "geom:longitude":80.565778,
@@ -268,17 +268,19 @@
         "gn:id":1228729,
         "gp:id":23706494,
         "hasc:id":"LK.RN",
+        "iso:code":"LK-91",
         "iso:id":"LK-91",
         "qs_pg:id":219948,
         "unlc:id":"LK-91",
         "wd:id":"Q1587175",
         "wk:page":"Ratnapura District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6576fa76cb3add12a7ac9ee8dc2b3412",
+    "wof:geomhash":"cb2b573c67ebce493566ca629198820a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -295,7 +297,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938540,
+    "wof:lastmodified":1695884871,
     "wof:name":"Ratnapura",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/89/85673789.geojson
+++ b/data/856/737/89/85673789.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.134356,
-    "geom:area_square_m":1651557151.865984,
+    "geom:area_square_m":1651556975.91669,
     "geom:bbox":"79.986252,5.957056,80.496828,6.438573",
     "geom:latitude":6.221199,
     "geom:longitude":80.250335,
@@ -258,17 +258,19 @@
         "gn:id":1246292,
         "gp:id":23706498,
         "hasc:id":"LK.GL",
+        "iso:code":"LK-31",
         "iso:id":"LK-31",
         "qs_pg:id":1086136,
         "unlc:id":"LK-31",
         "wd:id":"Q647649",
         "wk:page":"Galle District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c87d7836a23a02e6c4007c5587ca13f4",
+    "wof:geomhash":"4150d788b6476434c09b8575f86de333",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -285,7 +287,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938537,
+    "wof:lastmodified":1695884361,
     "wof:name":"G\u0101lla",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/91/85673791.geojson
+++ b/data/856/737/91/85673791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.218426,
-    "geom:area_square_m":2684776116.972408,
+    "geom:area_square_m":2684776883.05719,
     "geom:bbox":"80.608318,5.969584,81.709587,6.576289",
     "geom:latitude":6.258842,
     "geom:longitude":81.101191,
@@ -261,17 +261,19 @@
         "gn:id":1244925,
         "gp:id":23706497,
         "hasc:id":"LK.HB",
+        "iso:code":"LK-33",
         "iso:id":"LK-33",
         "qs_pg:id":219949,
         "unlc:id":"LK-33",
         "wd:id":"Q723006",
         "wk:page":"Hambantota District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"74af01d65504cb51fd003c3c43cf5653",
+    "wof:geomhash":"d4bdcff4b4ab04c97760d5b69486f98a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -288,7 +290,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938539,
+    "wof:lastmodified":1695884361,
     "wof:name":"Hambant\u014f\u1e6da",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/737/95/85673795.geojson
+++ b/data/856/737/95/85673795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.108219,
-    "geom:area_square_m":1330473895.99748,
+    "geom:area_square_m":1330474105.137689,
     "geom:bbox":"80.375544,5.914556,80.725846,6.400067",
     "geom:latitude":6.140032,
     "geom:longitude":80.540154,
@@ -258,17 +258,19 @@
         "gn:id":1235845,
         "gp:id":23706496,
         "hasc:id":"LK.MH",
+        "iso:code":"LK-32",
         "iso:id":"LK-32",
         "qs_pg:id":888261,
         "unlc:id":"LK-32",
         "wd:id":"Q1281285",
         "wk:page":"Matara District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"04df57ac25d021dd9628df89761ff562",
+    "wof:geomhash":"208accfe4b150a9d7900daecc23766c2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -285,7 +287,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938536,
+    "wof:lastmodified":1695884361,
     "wof:name":"M\u0101tara",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/738/01/85673801.geojson
+++ b/data/856/738/01/85673801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.235188,
-    "geom:area_square_m":2885975816.44275,
+    "geom:area_square_m":2885975255.6508,
     "geom:bbox":"80.778202,6.547505,81.272934,7.613972",
     "geom:latitude":7.074683,
     "geom:longitude":81.044773,
@@ -264,17 +264,19 @@
         "gn:id":1250614,
         "gp:id":23706499,
         "hasc:id":"LK.BD",
+        "iso:code":"LK-81",
         "iso:id":"LK-81",
         "qs_pg:id":219950,
         "unlc:id":"LK-81",
         "wd:id":"Q799713",
         "wk:page":"Badulla District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"730dcef3d5e99538fc32b3681ecebdf2",
+    "wof:geomhash":"0667f0e8fe3c7a357d952c8bf096b7bc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -291,7 +293,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938542,
+    "wof:lastmodified":1695884871,
     "wof:name":"Badulla",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/738/03/85673803.geojson
+++ b/data/856/738/03/85673803.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.471217,
-    "geom:area_square_m":5785795178.110086,
+    "geom:area_square_m":5785794549.652345,
     "geom:bbox":"80.829088,6.297704,81.636608,7.458746",
     "geom:latitude":6.787145,
     "geom:longitude":81.303769,
@@ -212,16 +212,18 @@
         "gn:id":1234818,
         "gp:id":23706500,
         "hasc:id":"LK.MJ",
+        "iso:code":"LK-82",
         "iso:id":"LK-82",
         "qs_pg:id":219951,
         "wd:id":"Q923420",
         "wk:page":"Monaragala District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"54cdbb39d111f08293229079cd91fec9",
+    "wof:geomhash":"64ec31e0dbb99cb7b7871415418fb43c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -238,7 +240,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938541,
+    "wof:lastmodified":1695884362,
     "wof:name":"M\u014f\u1e47ar\u0101gala",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/738/07/85673807.geojson
+++ b/data/856/738/07/85673807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.136112,
-    "geom:area_square_m":1670121147.126261,
+    "geom:area_square_m":1670120929.632138,
     "geom:bbox":"80.150923,6.828223,80.545552,7.396812",
     "geom:latitude":7.104498,
     "geom:longitude":80.343308,
@@ -258,15 +258,17 @@
         "gn:id":1240722,
         "gp:id":23706495,
         "hasc:id":"LK.KE",
+        "iso:code":"LK-92",
         "iso:id":"LK-92",
         "qs_pg:id":891829,
         "wd:id":"Q1737803"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2264e47fcdb8af9fe60fa24aaf07b995",
+    "wof:geomhash":"848b5d22a14be143d189cf24615dfd85",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -283,7 +285,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938542,
+    "wof:lastmodified":1695884362,
     "wof:name":"K\u00e6galla",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/738/11/85673811.geojson
+++ b/data/856/738/11/85673811.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055901,
-    "geom:area_square_m":686264547.183241,
+    "geom:area_square_m":686265296.746038,
     "geom:bbox":"79.840385,6.746444,80.223043,6.983537",
     "geom:latitude":6.86958,
     "geom:longitude":80.019675,
@@ -234,17 +234,19 @@
         "gn:id":1248990,
         "gp:id":23706493,
         "hasc:id":"LK.CO",
+        "iso:code":"LK-11",
         "iso:id":"LK-11",
         "qs_pg:id":896539,
         "unlc:id":"LK-11",
         "wd:id":"Q606287",
         "wk:page":"Colombo District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1c8840fc4e536b1465f9e6a45b1b8b89",
+    "wof:geomhash":"5447b91cbe61a7643828748b4a721094",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -261,7 +263,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938541,
+    "wof:lastmodified":1695884362,
     "wof:name":"K\u014f\u1e37amba",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/738/15/85673815.geojson
+++ b/data/856/738/15/85673815.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.11351,
-    "geom:area_square_m":1392742585.657601,
+    "geom:area_square_m":1392742841.177447,
     "geom:bbox":"79.816803,6.908089,80.209734,7.330748",
     "geom:latitude":7.123189,
     "geom:longitude":80.018146,
@@ -267,17 +267,19 @@
         "gn:id":1246005,
         "gp:id":23706491,
         "hasc:id":"LK.GQ",
+        "iso:code":"LK-12",
         "iso:id":"LK-12",
         "qs_pg:id":896537,
         "unlc:id":"LK-12",
         "wd:id":"Q206344",
         "wk:page":"Gampaha District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"090da83d3dbd9845a213873a4691e2b1",
+    "wof:geomhash":"f1b19a2c92691a1a9086b23d93d24f60",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -294,7 +296,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938542,
+    "wof:lastmodified":1695884871,
     "wof:name":"Gampaha",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/856/738/19/85673819.geojson
+++ b/data/856/738/19/85673819.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.136154,
-    "geom:area_square_m":1672489021.240275,
+    "geom:area_square_m":1672488435.820205,
     "geom:bbox":"79.878959,6.327663,80.380548,6.826418",
     "geom:latitude":6.578199,
     "geom:longitude":80.125037,
@@ -257,17 +257,19 @@
         "gn:id":1241963,
         "gp:id":23706492,
         "hasc:id":"LK.KT",
+        "iso:code":"LK-13",
         "iso:id":"LK-13",
         "qs_pg:id":896538,
         "unlc:id":"LK-13",
         "wd:id":"Q728935",
         "wk:page":"Kalutara District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2b7e08b60b841f61b2a17a68ca5b0986",
+    "wof:geomhash":"b86bd3d21ea704b8b87ea022fa414ec5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -284,7 +286,7 @@
         "sin",
         "tam"
     ],
-    "wof:lastmodified":1690938542,
+    "wof:lastmodified":1695884362,
     "wof:name":"Ka\u1e37utara",
     "wof:parent_id":85632313,
     "wof:placetype":"region",

--- a/data/890/450/157/890450157.geojson
+++ b/data/890/450/157/890450157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010173,
-    "geom:area_square_m":124777378.076978,
+    "geom:area_square_m":124777648.024846,
     "geom:bbox":"81.488187,7.216805,81.706902,7.321543",
     "geom:latitude":7.272485,
     "geom:longitude":81.591954,
@@ -210,12 +210,13 @@
         "wd:id":"Q474395",
         "wk:page":"Ampara District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1469052728,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8a413dcc9744d6dc078a320658294e69",
+    "wof:geomhash":"e1dcea33d97bcbbb51bcfe819735abfc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -225,7 +226,7 @@
         }
     ],
     "wof:id":890450157,
-    "wof:lastmodified":1690938576,
+    "wof:lastmodified":1695886782,
     "wof:name":"Ampara",
     "wof:parent_id":85673733,
     "wof:placetype":"county",

--- a/data/890/455/861/890455861.geojson
+++ b/data/890/455/861/890455861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008584,
-    "geom:area_square_m":105301250.794996,
+    "geom:area_square_m":105301416.013948,
     "geom:bbox":"80.314428,7.114225,80.413152,7.283981",
     "geom:latitude":7.205342,
     "geom:longitude":80.367255,
@@ -204,12 +204,13 @@
         "wd:id":"Q1737803",
         "wk:page":"Kegalle District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1469052978,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"537164a0afb5b4f3de2cfbf0fc081242",
+    "wof:geomhash":"7cb6359c505d37ba403428679acbfd79",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -219,7 +220,7 @@
         }
     ],
     "wof:id":890455861,
-    "wof:lastmodified":1690938574,
+    "wof:lastmodified":1695886782,
     "wof:name":"Kegalle",
     "wof:parent_id":85673807,
     "wof:placetype":"county",

--- a/data/890/455/863/890455863.geojson
+++ b/data/890/455/863/890455863.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000906,
-    "geom:area_square_m":11040715.340612,
+    "geom:area_square_m":11040559.468685,
     "geom:bbox":"80.000137,9.642889,80.044492,9.681768",
     "geom:latitude":9.660149,
     "geom:longitude":80.022453,
@@ -156,12 +156,13 @@
         "wd:id":"Q1520182",
         "wk:page":"Jaffna District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"LK",
     "wof:created":1469052978,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"abe0268fb66ac064d1da7d4382bd4716",
+    "wof:geomhash":"8bdcc8275bac719216bd81ea8de698ef",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -171,7 +172,7 @@
         }
     ],
     "wof:id":890455863,
-    "wof:lastmodified":1690938574,
+    "wof:lastmodified":1695886782,
     "wof:name":"Jaffna",
     "wof:parent_id":85673769,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.